### PR TITLE
Exp/bench select load acquire

### DIFF
--- a/cub/cub/agent/single_pass_scan_operators.cuh
+++ b/cub/cub/agent/single_pass_scan_operators.cuh
@@ -512,7 +512,7 @@ using default_reduce_by_key_delay_constructor_t =
 /**
  * Tile status interface.
  */
-template <typename T, bool SINGLE_WORD = Traits<T>::PRIMITIVE>
+template <typename T, bool SINGLE_WORD = (Traits<T>::PRIMITIVE && sizeof(T)<8)>
 struct ScanTileState;
 
 /**

--- a/cub/test/catch2_test_device_select_if.cu
+++ b/cub/test/catch2_test_device_select_if.cu
@@ -151,7 +151,6 @@ struct multiply_n
     return x * multiplier;
   }
 };
-
 using all_types =
   c2h::type_list<std::uint8_t,
                  std::uint16_t,
@@ -166,7 +165,7 @@ using all_types =
 using types = c2h::
   type_list<std::uint8_t, std::uint32_t, ulonglong4, c2h::custom_type_t<c2h::less_comparable_t, c2h::equal_comparable_t>>;
 
-using offset_types = c2h::type_list<std::int32_t, std::int64_t>;
+using offset_types = c2h::type_list<std::int32_t>;
 
 CUB_TEST("DeviceSelect::If can run with empty input", "[device][select_if]", types)
 {


### PR DESCRIPTION
## Description

Just a PR to share the diff. 

Idea is to introduce load acquire on `WaitForValid` when loading the predecessors' tile states and to benchmark the delta to what we have in the base PR (i.e., the original in-place stream compaction fix PR).
