### PR TITLE
[DRAFT] Experimenting with bool tile state in `ScanByKey`

### DIFF
--- a/cub/cub/agent/agent_scan_by_key.cuh
+++ b/cub/cub/agent/agent_scan_by_key.cuh
@@ -201,7 +201,6 @@ struct AgentScanByKey
 
   TempStorage_& storage;
   WrappedKeysInputIteratorT d_keys_in;
-  KeyT* d_keys_prev_in;
   WrappedValuesInputIteratorT d_values_in;
   ValuesOutputIteratorT d_values_out;
   InequalityWrapper<EqualityOp> inequality_op;
@@ -373,7 +372,7 @@ struct AgentScanByKey
     }
     else
     {
-      KeyT tile_pred_key = (threadIdx.x == 0) ? d_keys_prev_in[tile_idx] : KeyT();
+      KeyT tile_pred_key = d_keys_in[tile_base - 1];
 
       BlockDiscontinuityKeysT(storage.scan_storage.discontinuity)
         .FlagHeads(segment_flags, keys, inequality_op, tile_pred_key);
@@ -412,7 +411,6 @@ struct AgentScanByKey
   _CCCL_DEVICE _CCCL_FORCEINLINE AgentScanByKey(
     TempStorage& storage,
     KeysInputIteratorT d_keys_in,
-    KeyT* d_keys_prev_in,
     ValuesInputIteratorT d_values_in,
     ValuesOutputIteratorT d_values_out,
     EqualityOp equality_op,
@@ -420,7 +418,6 @@ struct AgentScanByKey
     InitValueT init_value)
       : storage(storage.Alias())
       , d_keys_in(d_keys_in)
-      , d_keys_prev_in(d_keys_prev_in)
       , d_values_in(d_values_in)
       , d_values_out(d_values_out)
       , inequality_op(equality_op)

--- a/cub/cub/agent/agent_scan_by_key.cuh
+++ b/cub/cub/agent/agent_scan_by_key.cuh
@@ -142,10 +142,10 @@ struct AgentScanByKey
 
   using KeyT               = cub::detail::value_t<KeysInputIteratorT>;
   using InputT             = cub::detail::value_t<ValuesInputIteratorT>;
-  using FlagValuePairT     = KeyValuePair<bool, AccumT>;
+  using FlagValuePairT     = KeyValuePair<int, AccumT>;
   using ReduceBySegmentOpT = ScanBySegmentOp<ScanOpT>;
 
-  using ScanTileStateT = ReduceByKeyScanTileState<AccumT, bool>;
+  using ScanTileStateT = ReduceByKeyScanTileState<AccumT, int>;
 
   // Constants
   // Inclusive scan if no init_value type is provided

--- a/cub/cub/agent/agent_scan_by_key.cuh
+++ b/cub/cub/agent/agent_scan_by_key.cuh
@@ -142,11 +142,10 @@ struct AgentScanByKey
 
   using KeyT               = cub::detail::value_t<KeysInputIteratorT>;
   using InputT             = cub::detail::value_t<ValuesInputIteratorT>;
-  using SizeValuePairT     = KeyValuePair<OffsetT, AccumT>;
-  using KeyValuePairT      = KeyValuePair<KeyT, AccumT>;
-  using ReduceBySegmentOpT = ReduceBySegmentOp<ScanOpT>;
+  using FlagValuePairT     = KeyValuePair<bool, AccumT>;
+  using ReduceBySegmentOpT = ScanBySegmentOp<ScanOpT>;
 
-  using ScanTileStateT = ReduceByKeyScanTileState<AccumT, OffsetT>;
+  using ScanTileStateT = ReduceByKeyScanTileState<AccumT, bool>;
 
   // Constants
   // Inclusive scan if no init_value type is provided
@@ -175,9 +174,9 @@ struct AgentScanByKey
 
   using DelayConstructorT = typename AgentScanByKeyPolicyT::detail::delay_constructor_t;
   using TilePrefixCallbackT =
-    TilePrefixCallbackOp<SizeValuePairT, ReduceBySegmentOpT, ScanTileStateT, 0, DelayConstructorT>;
+    TilePrefixCallbackOp<FlagValuePairT, ReduceBySegmentOpT, ScanTileStateT, 0, DelayConstructorT>;
 
-  using BlockScanT = BlockScan<SizeValuePairT, BLOCK_THREADS, AgentScanByKeyPolicyT::SCAN_ALGORITHM, 1, 1>;
+  using BlockScanT = BlockScan<FlagValuePairT, BLOCK_THREADS, AgentScanByKeyPolicyT::SCAN_ALGORITHM, 1, 1>;
 
   union TempStorage_
   {
@@ -216,14 +215,14 @@ struct AgentScanByKey
 
   // Exclusive scan specialization
   _CCCL_DEVICE _CCCL_FORCEINLINE void ScanTile(
-    SizeValuePairT (&scan_items)[ITEMS_PER_THREAD], SizeValuePairT& tile_aggregate, Int2Type<false> /* is_inclusive */)
+    FlagValuePairT (&scan_items)[ITEMS_PER_THREAD], FlagValuePairT& tile_aggregate, Int2Type<false> /* is_inclusive */)
   {
     BlockScanT(storage.scan_storage.scan).ExclusiveScan(scan_items, scan_items, pair_scan_op, tile_aggregate);
   }
 
   // Inclusive scan specialization
   _CCCL_DEVICE _CCCL_FORCEINLINE void ScanTile(
-    SizeValuePairT (&scan_items)[ITEMS_PER_THREAD], SizeValuePairT& tile_aggregate, Int2Type<true> /* is_inclusive */)
+    FlagValuePairT (&scan_items)[ITEMS_PER_THREAD], FlagValuePairT& tile_aggregate, Int2Type<true> /* is_inclusive */)
   {
     BlockScanT(storage.scan_storage.scan).InclusiveScan(scan_items, scan_items, pair_scan_op, tile_aggregate);
   }
@@ -234,8 +233,8 @@ struct AgentScanByKey
 
   // Exclusive scan specialization (with prefix from predecessors)
   _CCCL_DEVICE _CCCL_FORCEINLINE void ScanTile(
-    SizeValuePairT (&scan_items)[ITEMS_PER_THREAD],
-    SizeValuePairT& tile_aggregate,
+    FlagValuePairT (&scan_items)[ITEMS_PER_THREAD],
+    FlagValuePairT& tile_aggregate,
     TilePrefixCallbackT& prefix_op,
     Int2Type<false> /* is_inclusive */)
   {
@@ -245,8 +244,8 @@ struct AgentScanByKey
 
   // Inclusive scan specialization (with prefix from predecessors)
   _CCCL_DEVICE _CCCL_FORCEINLINE void ScanTile(
-    SizeValuePairT (&scan_items)[ITEMS_PER_THREAD],
-    SizeValuePairT& tile_aggregate,
+    FlagValuePairT (&scan_items)[ITEMS_PER_THREAD],
+    FlagValuePairT& tile_aggregate,
     TilePrefixCallbackT& prefix_op,
     Int2Type<true> /* is_inclusive */)
   {
@@ -263,7 +262,7 @@ struct AgentScanByKey
     OffsetT num_remaining,
     AccumT (&values)[ITEMS_PER_THREAD],
     OffsetT (&segment_flags)[ITEMS_PER_THREAD],
-    SizeValuePairT (&scan_items)[ITEMS_PER_THREAD])
+    FlagValuePairT (&scan_items)[ITEMS_PER_THREAD])
   {
 // Zip values and segment_flags
 #pragma unroll
@@ -281,7 +280,7 @@ struct AgentScanByKey
   }
 
   _CCCL_DEVICE _CCCL_FORCEINLINE void
-  UnzipValues(AccumT (&values)[ITEMS_PER_THREAD], SizeValuePairT (&scan_items)[ITEMS_PER_THREAD])
+  UnzipValues(AccumT (&values)[ITEMS_PER_THREAD], FlagValuePairT (&scan_items)[ITEMS_PER_THREAD])
   {
 // Unzip values and segment_flags
 #pragma unroll
@@ -321,7 +320,7 @@ struct AgentScanByKey
     KeyT keys[ITEMS_PER_THREAD];
     AccumT values[ITEMS_PER_THREAD];
     OffsetT segment_flags[ITEMS_PER_THREAD];
-    SizeValuePairT scan_items[ITEMS_PER_THREAD];
+    FlagValuePairT scan_items[ITEMS_PER_THREAD];
 
     if (IS_LAST_TILE)
     {
@@ -359,7 +358,7 @@ struct AgentScanByKey
       ZipValuesAndFlags<IS_LAST_TILE>(num_remaining, values, segment_flags, scan_items);
 
       // Exclusive scan of values and segment_flags
-      SizeValuePairT tile_aggregate;
+      FlagValuePairT tile_aggregate;
       ScanTile(scan_items, tile_aggregate, Int2Type<IS_INCLUSIVE>());
 
       if (threadIdx.x == 0)
@@ -382,7 +381,7 @@ struct AgentScanByKey
       // Zip values and segment_flags
       ZipValuesAndFlags<IS_LAST_TILE>(num_remaining, values, segment_flags, scan_items);
 
-      SizeValuePairT tile_aggregate;
+      FlagValuePairT tile_aggregate;
       TilePrefixCallbackT prefix_op(tile_state, storage.scan_storage.prefix, pair_scan_op, tile_idx);
       ScanTile(scan_items, tile_aggregate, prefix_op, Int2Type<IS_INCLUSIVE>());
     }

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -1528,6 +1528,9 @@ struct DeviceScan
   //!   **[inferred]** Functor type having member
   //!   `T operator()(const T &a, const T &b)` for binary operations that defines the equality of keys
   //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** An integral type representing the number of input elements
+  //!
   //! @param[in] d_temp_storage
   //!   Device-accessible allocation of temporary storage. When `nullptr`, the
   //!   required allocation size is written to `temp_storage_bytes` and no work is done.
@@ -1558,21 +1561,22 @@ struct DeviceScan
   template <typename KeysInputIteratorT,
             typename ValuesInputIteratorT,
             typename ValuesOutputIteratorT,
-            typename EqualityOpT = Equality>
+            typename EqualityOpT = Equality,
+            typename NumItemsT   = std::uint32_t>
   CUB_RUNTIME_FUNCTION static cudaError_t ExclusiveSumByKey(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeysInputIteratorT d_keys_in,
     ValuesInputIteratorT d_values_in,
     ValuesOutputIteratorT d_values_out,
-    int num_items,
+    NumItemsT num_items,
     EqualityOpT equality_op = EqualityOpT(),
     cudaStream_t stream     = 0)
   {
     CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceScan::ExclusiveSumByKey");
 
-    // Signed integer type for global offsets
-    using OffsetT = int;
+    // Unsigned integer type for global offsets
+    using OffsetT = detail::choose_offset_t<NumItemsT>;
     using InitT   = cub::detail::value_t<ValuesInputIteratorT>;
 
     // Initial value
@@ -1601,14 +1605,15 @@ struct DeviceScan
   template <typename KeysInputIteratorT,
             typename ValuesInputIteratorT,
             typename ValuesOutputIteratorT,
-            typename EqualityOpT = Equality>
+            typename EqualityOpT = Equality,
+            typename NumItemsT   = std::uint32_t>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED CUB_RUNTIME_FUNCTION static cudaError_t ExclusiveSumByKey(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeysInputIteratorT d_keys_in,
     ValuesInputIteratorT d_values_in,
     ValuesOutputIteratorT d_values_out,
-    int num_items,
+    NumItemsT num_items,
     EqualityOpT equality_op,
     cudaStream_t stream,
     bool debug_synchronous)
@@ -1721,6 +1726,9 @@ struct DeviceScan
   //!   **[inferred]** Functor type having member
   //!   `T operator()(const T &a, const T &b)` for binary operations that defines the equality of keys
   //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** An integral type representing the number of input elements
+  //!
   //!  @param[in] d_temp_storage
   //!    Device-accessible allocation of temporary storage. When `nullptr`, the
   //!    required allocation size is written to `temp_storage_bytes` and no work is done.
@@ -1761,7 +1769,8 @@ struct DeviceScan
             typename ValuesOutputIteratorT,
             typename ScanOpT,
             typename InitValueT,
-            typename EqualityOpT = Equality>
+            typename EqualityOpT = Equality,
+            typename NumItemsT   = std::uint32_t>
   CUB_RUNTIME_FUNCTION static cudaError_t ExclusiveScanByKey(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -1770,14 +1779,14 @@ struct DeviceScan
     ValuesOutputIteratorT d_values_out,
     ScanOpT scan_op,
     InitValueT init_value,
-    int num_items,
+    NumItemsT num_items,
     EqualityOpT equality_op = EqualityOpT(),
     cudaStream_t stream     = 0)
   {
     CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceScan::ExclusiveScanByKey");
 
-    // Signed integer type for global offsets
-    using OffsetT = int;
+    // Unsigned integer type for global offsets
+    using OffsetT = detail::choose_offset_t<NumItemsT>;
 
     return DispatchScanByKey<
       KeysInputIteratorT,
@@ -1804,7 +1813,8 @@ struct DeviceScan
             typename ValuesOutputIteratorT,
             typename ScanOpT,
             typename InitValueT,
-            typename EqualityOpT = Equality>
+            typename EqualityOpT = Equality,
+            typename NumItemsT   = std::uint32_t>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED CUB_RUNTIME_FUNCTION static cudaError_t ExclusiveScanByKey(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -1813,7 +1823,7 @@ struct DeviceScan
     ValuesOutputIteratorT d_values_out,
     ScanOpT scan_op,
     InitValueT init_value,
-    int num_items,
+    NumItemsT num_items,
     EqualityOpT equality_op,
     cudaStream_t stream,
     bool debug_synchronous)
@@ -1904,6 +1914,9 @@ struct DeviceScan
   //!   **[inferred]** Functor type having member
   //!   `T operator()(const T &a, const T &b)` for binary operations that defines the equality of keys
   //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** An integral type representing the number of input elements
+  //!
   //!  @param[in] d_temp_storage
   //!    Device-accessible allocation of temporary storage.
   //!    When `nullptr`, the required allocation size is written to `temp_storage_bytes` and no work is done.
@@ -1934,21 +1947,22 @@ struct DeviceScan
   template <typename KeysInputIteratorT,
             typename ValuesInputIteratorT,
             typename ValuesOutputIteratorT,
-            typename EqualityOpT = Equality>
+            typename EqualityOpT = Equality,
+            typename NumItemsT   = std::uint32_t>
   CUB_RUNTIME_FUNCTION static cudaError_t InclusiveSumByKey(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeysInputIteratorT d_keys_in,
     ValuesInputIteratorT d_values_in,
     ValuesOutputIteratorT d_values_out,
-    int num_items,
+    NumItemsT num_items,
     EqualityOpT equality_op = EqualityOpT(),
     cudaStream_t stream     = 0)
   {
     CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceScan::InclusiveSumByKey");
 
-    // Signed integer type for global offsets
-    using OffsetT = int;
+    // Unsigned integer type for global offsets
+    using OffsetT = detail::choose_offset_t<NumItemsT>;
 
     return DispatchScanByKey<
       KeysInputIteratorT,
@@ -1973,14 +1987,15 @@ struct DeviceScan
   template <typename KeysInputIteratorT,
             typename ValuesInputIteratorT,
             typename ValuesOutputIteratorT,
-            typename EqualityOpT = Equality>
+            typename EqualityOpT = Equality,
+            typename NumItemsT   = std::uint32_t>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED CUB_RUNTIME_FUNCTION static cudaError_t InclusiveSumByKey(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
     KeysInputIteratorT d_keys_in,
     ValuesInputIteratorT d_values_in,
     ValuesOutputIteratorT d_values_out,
-    int num_items,
+    NumItemsT num_items,
     EqualityOpT equality_op,
     cudaStream_t stream,
     bool debug_synchronous)
@@ -2084,6 +2099,9 @@ struct DeviceScan
   //!   **[inferred]** Functor type having member
   //!   `T operator()(const T &a, const T &b)` for binary operations that defines the equality of keys
   //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** An integral type representing the number of input elements
+  //!
   //!  @param[in] d_temp_storage
   //!    Device-accessible allocation of temporary storage.
   //!    When `nullptr`, the required allocation size is written to `temp_storage_bytes` and no work is done.
@@ -2118,7 +2136,8 @@ struct DeviceScan
             typename ValuesInputIteratorT,
             typename ValuesOutputIteratorT,
             typename ScanOpT,
-            typename EqualityOpT = Equality>
+            typename EqualityOpT = Equality,
+            typename NumItemsT   = std::uint32_t>
   CUB_RUNTIME_FUNCTION static cudaError_t InclusiveScanByKey(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -2126,14 +2145,14 @@ struct DeviceScan
     ValuesInputIteratorT d_values_in,
     ValuesOutputIteratorT d_values_out,
     ScanOpT scan_op,
-    int num_items,
+    NumItemsT num_items,
     EqualityOpT equality_op = EqualityOpT(),
     cudaStream_t stream     = 0)
   {
     CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceScan::InclusiveScanByKey");
 
-    // Signed integer type for global offsets
-    using OffsetT = int;
+    // Unsigned integer type for global offsets
+    using OffsetT = detail::choose_offset_t<NumItemsT>;
 
     return DispatchScanByKey<
       KeysInputIteratorT,
@@ -2159,7 +2178,8 @@ struct DeviceScan
             typename ValuesInputIteratorT,
             typename ValuesOutputIteratorT,
             typename ScanOpT,
-            typename EqualityOpT = Equality>
+            typename EqualityOpT = Equality,
+            typename NumItemsT   = std::uint32_t>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED CUB_RUNTIME_FUNCTION static cudaError_t InclusiveScanByKey(
     void* d_temp_storage,
     size_t& temp_storage_bytes,
@@ -2167,7 +2187,7 @@ struct DeviceScan
     ValuesInputIteratorT d_values_in,
     ValuesOutputIteratorT d_values_out,
     ScanOpT scan_op,
-    int num_items,
+    NumItemsT num_items,
     EqualityOpT equality_op,
     cudaStream_t stream,
     bool debug_synchronous)

--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -248,6 +248,9 @@ struct DispatchScanByKey : SelectedPolicy
   // The input value type
   using InputT = cub::detail::value_t<ValuesInputIteratorT>;
 
+  // Tile state used for the decoupled look-back
+  using ScanByKeyTileStateT = ReduceByKeyScanTileState<AccumT, bool>;
+
   /// Device-accessible allocation of temporary storage. When `nullptr`, the
   /// required allocation size is written to `temp_storage_bytes` and no work
   /// is done.
@@ -374,7 +377,6 @@ struct DispatchScanByKey : SelectedPolicy
   CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t Invoke(InitKernel init_kernel, ScanKernel scan_kernel)
   {
     using Policy              = typename ActivePolicyT::ScanByKeyPolicyT;
-    using ScanByKeyTileStateT = ReduceByKeyScanTileState<AccumT, OffsetT>;
 
     cudaError error = cudaSuccess;
     do
@@ -530,7 +532,6 @@ struct DispatchScanByKey : SelectedPolicy
   CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t Invoke()
   {
     using MaxPolicyT          = typename DispatchScanByKey::MaxPolicy;
-    using ScanByKeyTileStateT = ReduceByKeyScanTileState<AccumT, OffsetT>;
 
     // Ensure kernels are instantiated.
     return Invoke<ActivePolicyT>(

--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -249,7 +249,7 @@ struct DispatchScanByKey : SelectedPolicy
   using InputT = cub::detail::value_t<ValuesInputIteratorT>;
 
   // Tile state used for the decoupled look-back
-  using ScanByKeyTileStateT = ReduceByKeyScanTileState<AccumT, bool>;
+  using ScanByKeyTileStateT = ReduceByKeyScanTileState<AccumT, int>;
 
   /// Device-accessible allocation of temporary storage. When `nullptr`, the
   /// required allocation size is written to `temp_storage_bytes` and no work

--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -170,19 +170,19 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ScanByKeyPolicyT::BLOCK_THRE
     .ConsumeRange(num_items, tile_state, start_tile);
 }
 
-template <typename ScanTileStateT, typename KeysInputIteratorT>
+template <typename ScanTileStateT, typename KeysInputIteratorT, typename OffsetT>
 CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceScanByKeyInitKernel(
   ScanTileStateT tile_state,
   KeysInputIteratorT d_keys_in,
   cub::detail::value_t<KeysInputIteratorT>* d_keys_prev_in,
-  unsigned items_per_tile,
+  OffsetT items_per_tile,
   int num_tiles)
 {
   // Initialize tile status
   tile_state.InitializeStatus(num_tiles);
 
-  const unsigned tid       = threadIdx.x + blockDim.x * blockIdx.x;
-  const unsigned tile_base = tid * items_per_tile;
+  const unsigned tid      = threadIdx.x + blockDim.x * blockIdx.x;
+  const OffsetT tile_base = static_cast<OffsetT>(tid) * items_per_tile;
 
   if (tid > 0 && tid < num_tiles)
   {
@@ -376,7 +376,7 @@ struct DispatchScanByKey : SelectedPolicy
   template <typename ActivePolicyT, typename InitKernel, typename ScanKernel>
   CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t Invoke(InitKernel init_kernel, ScanKernel scan_kernel)
   {
-    using Policy              = typename ActivePolicyT::ScanByKeyPolicyT;
+    using Policy = typename ActivePolicyT::ScanByKeyPolicyT;
 
     cudaError error = cudaSuccess;
     do
@@ -444,7 +444,7 @@ struct DispatchScanByKey : SelectedPolicy
 
       // Invoke init_kernel to initialize tile descriptors
       THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(init_grid_size, INIT_KERNEL_THREADS, 0, stream)
-        .doit(init_kernel, tile_state, d_keys_in, d_keys_prev_in, tile_size, num_tiles);
+        .doit(init_kernel, tile_state, d_keys_in, d_keys_prev_in, static_cast<OffsetT>(tile_size), num_tiles);
 
       // Check for failure to launch
       error = CubDebug(cudaPeekAtLastError());
@@ -454,18 +454,7 @@ struct DispatchScanByKey : SelectedPolicy
       }
 
       // Sync the stream if specified to flush runtime errors
-
       error = CubDebug(detail::DebugSyncStream(stream));
-      if (cudaSuccess != error)
-      {
-        break;
-      }
-
-      // Get SM occupancy for scan_kernel
-      int scan_sm_occupancy;
-      error = CubDebug(MaxSmOccupancy(scan_sm_occupancy, // out
-                                      scan_kernel,
-                                      Policy::BLOCK_THREADS));
       if (cudaSuccess != error)
       {
         break;
@@ -486,13 +475,12 @@ struct DispatchScanByKey : SelectedPolicy
 // Log scan_kernel configuration
 #ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
         _CubLog("Invoking %d scan_kernel<<<%d, %d, 0, %lld>>>(), %d items "
-                "per thread, %d SM occupancy\n",
+                "per thread\n",
                 start_tile,
                 scan_grid_size,
                 Policy::BLOCK_THREADS,
                 (long long) stream,
-                Policy::ITEMS_PER_THREAD,
-                scan_sm_occupancy);
+                Policy::ITEMS_PER_THREAD);
 #endif // CUB_DETAIL_DEBUG_ENABLE_LOG
 
         // Invoke scan_kernel
@@ -531,11 +519,11 @@ struct DispatchScanByKey : SelectedPolicy
   template <typename ActivePolicyT>
   CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t Invoke()
   {
-    using MaxPolicyT          = typename DispatchScanByKey::MaxPolicy;
+    using MaxPolicyT = typename DispatchScanByKey::MaxPolicy;
 
     // Ensure kernels are instantiated.
     return Invoke<ActivePolicyT>(
-      DeviceScanByKeyInitKernel<ScanByKeyTileStateT, KeysInputIteratorT>,
+      DeviceScanByKeyInitKernel<ScanByKeyTileStateT, KeysInputIteratorT, OffsetT>,
       DeviceScanByKeyKernel<MaxPolicyT,
                             KeysInputIteratorT,
                             ValuesInputIteratorT,

--- a/cub/test/catch2_test_device_scan_by_key_large_offsets.cu
+++ b/cub/test/catch2_test_device_scan_by_key_large_offsets.cu
@@ -1,0 +1,157 @@
+/******************************************************************************
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#include "insert_nested_NVTX_range_guard.h"
+// above header needs to be included first
+
+#include <cub/device/device_scan.cuh>
+
+#include <cstdint>
+
+#include "catch2_test_helper.h"
+#include "catch2_test_launch_helper.h"
+
+DECLARE_LAUNCH_WRAPPER(cub::DeviceScan::ExclusiveScanByKey, device_exclusive_scan_by_key);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceScan::InclusiveScanByKey, device_inclusive_scan_by_key);
+
+// %PARAM% TEST_LAUNCH lid 0:1:2
+
+// List of offset types to be used for testing large number of items
+// using offset_types = c2h::type_list<std::uint32_t, std::uint64_t>;
+using offset_types = c2h::type_list<std::uint64_t>;
+
+template <typename ItemT, bool IsExclusive>
+struct expected_sum_op
+{
+  uint64_t segment_size;
+  ItemT init_value;
+
+  __host__ __device__ __forceinline__ ItemT operator()(const uint64_t index) const
+  {
+    uint64_t index_within_segment = index % segment_size;
+    uint64_t full_segments        = index / segment_size;
+
+    uint64_t sum_within_partial_segment{};
+    if (IsExclusive)
+    {
+      sum_within_partial_segment = (index_within_segment * (index_within_segment - 1)) / 2;
+    }
+    else
+    {
+      sum_within_partial_segment = (index_within_segment * (index_within_segment + 1)) / 2;
+    }
+    return index_within_segment == 0
+           ? (IsExclusive ? init_value : init_value + full_segments)
+           : static_cast<ItemT>(sum_within_partial_segment + full_segments) + init_value;
+  }
+};
+
+template <typename ItemT>
+struct mod_op
+{
+  uint64_t segment_size;
+
+  __host__ __device__ __forceinline__ uint64_t operator()(const uint64_t index) const
+  {
+    auto mod = static_cast<ItemT>(index % segment_size);
+    auto div = static_cast<ItemT>(index / segment_size);
+    return mod == 0 ? div : mod;
+  }
+};
+
+template <typename KeyT>
+struct div_op
+{
+  uint64_t segment_size;
+
+  __host__ __device__ __forceinline__ KeyT operator()(const uint64_t index) const
+  {
+    return static_cast<KeyT>(index / segment_size);
+  }
+};
+
+CUB_TEST("DeviceScan::ScanByKey works for very large number of items", "[by_key][scan][device]", offset_types)
+try
+{
+  using op_t     = cub::Sum;
+  using item_t   = std::uint32_t;
+  using key_t    = std::uint64_t;
+  using index_t  = std::uint64_t;
+  using offset_t = typename c2h::get<0, TestType>;
+
+  // Clamp 64-bit offset type problem sizes to just slightly larger than 2^32 items
+  auto num_items_max_ull =
+    std::min(static_cast<std::size_t>(::cuda::std::numeric_limits<offset_t>::max()),
+             ::cuda::std::numeric_limits<std::uint32_t>::max() + static_cast<std::size_t>(2000000ULL));
+  offset_t num_items_max = static_cast<offset_t>(num_items_max_ull);
+  offset_t num_items_min =
+    num_items_max_ull > 10000 ? static_cast<offset_t>(num_items_max_ull - 10000ULL) : offset_t{0};
+  offset_t num_items = GENERATE_COPY(
+    values(
+      {num_items_max, static_cast<offset_t>(num_items_max - 1), static_cast<offset_t>(1), static_cast<offset_t>(3)}),
+    take(2, random(num_items_min, num_items_max)));
+
+  // Prepare input (generate a series of: 0, 1, 2, ..., <segment_size-1>,  1, 1, 2, ..., <segment_size-1>, 2, 1, ...)
+  const index_t segment_size = GENERATE_COPY(values({offset_t{1000}, offset_t{1}}));
+  auto index_it              = thrust::make_counting_iterator(index_t{});
+  auto keys_it               = thrust::make_transform_iterator(index_it, div_op<key_t>{segment_size});
+  auto items_it              = thrust::make_transform_iterator(index_it, mod_op<item_t>{segment_size});
+
+  // Output memory allocation
+  c2h::device_vector<item_t> d_items_out(num_items);
+  auto d_items_out_it = thrust::raw_pointer_cast(d_items_out.data());
+
+  // Run test
+  SECTION("ExclusiveScanByKey")
+  {
+    constexpr bool is_exclusive = true;
+    auto initial_value          = item_t{42};
+    device_exclusive_scan_by_key(keys_it, items_it, d_items_out_it, op_t{}, initial_value, num_items, cub::Equality{});
+
+    // Ensure that we created the correct output
+    auto expected_out_it = thrust::make_transform_iterator(
+      index_it, expected_sum_op<item_t, is_exclusive>{static_cast<index_t>(segment_size), initial_value});
+    bool all_results_correct = thrust::equal(d_items_out.cbegin(), d_items_out.cend(), expected_out_it);
+    REQUIRE(all_results_correct == true);
+  }
+  SECTION("InclusiveScanByKey")
+  {
+    constexpr bool is_exclusive = false;
+    auto initial_value          = item_t{0};
+    device_inclusive_scan_by_key(keys_it, items_it, d_items_out_it, op_t{}, num_items, cub::Equality{});
+
+    // Ensure that we created the correct output
+    auto expected_out_it = thrust::make_transform_iterator(
+      index_it, expected_sum_op<item_t, is_exclusive>{static_cast<index_t>(segment_size), initial_value});
+    bool all_results_correct = thrust::equal(d_items_out.cbegin(), d_items_out.cend(), expected_out_it);
+    REQUIRE(all_results_correct == true);
+  }
+}
+catch (std::bad_alloc&)
+{
+  // Exceeding memory is not a failure.
+}


### PR DESCRIPTION
## Description

PR just to serve as a log for perf results.

Unfortunately, already minor changes severely degrade performance by double-digit:


## [0] NVIDIA H100 PCIe

|  KeyT{ct}  |  ValueT{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|------------|--------------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|     I8     |      I8      |      I32      |      2^16      |  10.497 us |       1.84% |  10.268 us |       2.11% |   -0.229 us |  -2.18% |   FAIL   |
|     I8     |      I8      |      I32      |      2^20      |  14.677 us |       1.73% |  14.659 us |       1.61% |   -0.018 us |  -0.12% |   PASS   |
|     I8     |      I8      |      I32      |      2^24      |  70.483 us |       0.93% |  75.868 us |       1.46% |    5.386 us |   7.64% |   FAIL   |
|     I8     |      I8      |      I32      |      2^28      | 951.726 us |       0.50% |   1.042 ms |       0.50% |   90.184 us |   9.48% |   FAIL   |
|     I8     |     I16      |      I32      |      2^16      |  12.024 us |       2.56% |  12.127 us |       2.33% |    0.103 us |   0.86% |   PASS   |
|     I8     |     I16      |      I32      |      2^20      |  15.669 us |       1.54% |  16.144 us |       2.00% |    0.475 us |   3.03% |   FAIL   |
|     I8     |     I16      |      I32      |      2^24      |  88.068 us |       0.96% |  88.755 us |       1.57% |    0.687 us |   0.78% |   PASS   |
|     I8     |     I16      |      I32      |      2^28      |   1.185 ms |       0.50% |   1.179 ms |       0.86% |   -6.109 us |  -0.52% |   FAIL   |
|     I8     |     I32      |      I32      |      2^16      |  11.320 us |       2.68% |  11.711 us |       2.31% |    0.391 us |   3.45% |   FAIL   |
|     I8     |     I32      |      I32      |      2^20      |  18.030 us |       1.53% |  18.297 us |       1.44% |    0.267 us |   1.48% |   FAIL   |
|     I8     |     I32      |      I32      |      2^24      | 102.756 us |       0.97% | 113.467 us |       1.52% |   10.712 us |  10.42% |   FAIL   |
|     I8     |     I32      |      I32      |      2^28      |   1.484 ms |       0.72% |   1.594 ms |       0.82% |  110.425 us |   7.44% |   FAIL   |
|     I8     |     I64      |      I32      |      2^16      |  11.560 us |       2.06% |  11.473 us |       1.93% |   -0.087 us |  -0.75% |   PASS   |
|     I8     |     I64      |      I32      |      2^20      |  21.241 us |       1.46% |  21.248 us |       1.54% |    0.007 us |   0.03% |   PASS   |
|     I8     |     I64      |      I32      |      2^24      | 175.693 us |       1.06% | 176.435 us |       1.01% |    0.741 us |   0.42% |   PASS   |
|     I8     |     I64      |      I32      |      2^28      |   2.634 ms |       0.54% |   2.641 ms |       0.54% |    7.246 us |   0.28% |   PASS   |
|     I8     |     I128     |      I32      |      2^16      |  16.102 us |       2.09% |  16.184 us |       1.58% |    0.083 us |   0.51% |   PASS   |
|     I8     |     I128     |      I32      |      2^20      |  40.387 us |       2.17% |  36.887 us |       1.64% |   -3.500 us |  -8.67% |   FAIL   |
|     I8     |     I128     |      I32      |      2^24      | 379.692 us |       0.48% | 346.446 us |       0.75% |  -33.246 us |  -8.76% |   FAIL   |
|     I8     |     I128     |      I32      |      2^28      |   5.853 ms |       0.14% |   5.279 ms |       0.24% | -574.233 us |  -9.81% |   FAIL   |
|    I16     |      I8      |      I32      |      2^16      |  10.539 us |       2.55% |  10.693 us |       2.30% |    0.155 us |   1.47% |   PASS   |
|    I16     |      I8      |      I32      |      2^20      |  16.173 us |       1.57% |  16.274 us |       1.43% |    0.101 us |   0.62% |   PASS   |
|    I16     |      I8      |      I32      |      2^24      |  77.880 us |       0.67% |  81.746 us |       1.24% |    3.866 us |   4.96% |   FAIL   |
|    I16     |      I8      |      I32      |      2^28      |   1.038 ms |       0.50% |   1.095 ms |       0.50% |   56.907 us |   5.48% |   FAIL   |
|    I16     |     I16      |      I32      |      2^16      |  11.656 us |       2.23% |  11.760 us |       2.36% |    0.103 us |   0.89% |   PASS   |
|    I16     |     I16      |      I32      |      2^20      |  16.880 us |       1.38% |  16.893 us |       1.34% |    0.014 us |   0.08% |   PASS   |
|    I16     |     I16      |      I32      |      2^24      |  90.700 us |       1.33% |  95.607 us |       2.03% |    4.908 us |   5.41% |   FAIL   |
|    I16     |     I16      |      I32      |      2^28      |   1.172 ms |       0.83% |   1.276 ms |       0.92% |  103.410 us |   8.82% |   FAIL   |
|    I16     |     I32      |      I32      |      2^16      |  11.790 us |       2.54% |  11.800 us |       2.20% |    0.010 us |   0.08% |   PASS   |
|    I16     |     I32      |      I32      |      2^20      |  17.985 us |       1.14% |  18.402 us |       1.32% |    0.416 us |   2.31% |   FAIL   |
|    I16     |     I32      |      I32      |      2^24      | 111.435 us |       1.12% | 114.722 us |       1.76% |    3.287 us |   2.95% |   FAIL   |
|    I16     |     I32      |      I32      |      2^28      |   1.599 ms |       0.70% |   1.643 ms |       0.84% |   43.553 us |   2.72% |   FAIL   |
|    I16     |     I64      |      I32      |      2^16      |  11.637 us |       2.40% |  11.843 us |       2.52% |    0.207 us |   1.78% |   PASS   |
|    I16     |     I64      |      I32      |      2^20      |  21.776 us |       1.33% |  21.977 us |       1.36% |    0.202 us |   0.93% |   PASS   |
|    I16     |     I64      |      I32      |      2^24      | 183.586 us |       1.01% | 184.316 us |       1.00% |    0.731 us |   0.40% |   PASS   |
|    I16     |     I64      |      I32      |      2^28      |   2.749 ms |       0.51% |   2.755 ms |       0.50% |    5.619 us |   0.20% |   PASS   |
|    I16     |     I128     |      I32      |      2^16      |  16.269 us |       1.88% |  16.348 us |       1.84% |    0.078 us |   0.48% |   PASS   |
|    I16     |     I128     |      I32      |      2^20      |  38.280 us |       1.40% |  38.004 us |       1.42% |   -0.275 us |  -0.72% |   PASS   |
|    I16     |     I128     |      I32      |      2^24      | 360.738 us |       0.71% | 355.686 us |       0.89% |   -5.051 us |  -1.40% |   FAIL   |
|    I16     |     I128     |      I32      |      2^28      |   5.512 ms |       0.17% |   5.428 ms |       0.24% |  -84.431 us |  -1.53% |   FAIL   |
|    I32     |      I8      |      I32      |      2^16      |  10.474 us |       2.34% |  10.994 us |       2.40% |    0.520 us |   4.96% |   FAIL   |
|    I32     |      I8      |      I32      |      2^20      |  16.605 us |       1.47% |  17.466 us |       1.48% |    0.861 us |   5.18% |   FAIL   |
|    I32     |      I8      |      I32      |      2^24      |  90.581 us |       1.05% |  99.586 us |       1.57% |    9.005 us |   9.94% |   FAIL   |
|    I32     |      I8      |      I32      |      2^28      |   1.161 ms |       0.73% |   1.306 ms |       0.72% |  144.959 us |  12.49% |   FAIL   |
|    I32     |     I16      |      I32      |      2^16      |  11.351 us |       2.12% |  11.999 us |       2.10% |    0.647 us |   5.70% |   FAIL   |
|    I32     |     I16      |      I32      |      2^20      |  17.284 us |       1.61% |  18.303 us |       1.52% |    1.019 us |   5.90% |   FAIL   |
|    I32     |     I16      |      I32      |      2^24      | 101.337 us |       1.17% | 109.691 us |       1.56% |    8.354 us |   8.24% |   FAIL   |
|    I32     |     I16      |      I32      |      2^28      |   1.407 ms |       0.73% |   1.469 ms |       0.84% |   62.015 us |   4.41% |   FAIL   |
|    I32     |     I32      |      I32      |      2^16      |  11.875 us |       2.01% |  12.315 us |       1.95% |    0.440 us |   3.71% |   FAIL   |
|    I32     |     I32      |      I32      |      2^20      |  18.782 us |       1.23% |  19.654 us |       1.54% |    0.872 us |   4.64% |   FAIL   |
|    I32     |     I32      |      I32      |      2^24      | 129.869 us |       1.09% | 131.834 us |       1.29% |    1.965 us |   1.51% |   FAIL   |
|    I32     |     I32      |      I32      |      2^28      |   1.909 ms |       0.57% |   1.931 ms |       0.62% |   22.369 us |   1.17% |   FAIL   |
|    I32     |     I64      |      I32      |      2^16      |  12.431 us |       2.29% |  12.892 us |       1.91% |    0.462 us |   3.71% |   FAIL   |
|    I32     |     I64      |      I32      |      2^20      |  22.756 us |       1.51% |  23.444 us |       1.21% |    0.688 us |   3.02% |   FAIL   |
|    I32     |     I64      |      I32      |      2^24      | 197.758 us |       0.91% | 210.262 us |       0.80% |   12.504 us |   6.32% |   FAIL   |
|    I32     |     I64      |      I32      |      2^28      |   2.942 ms |       0.50% |   3.147 ms |       0.50% |  205.520 us |   6.99% |   FAIL   |
|    I32     |     I128     |      I32      |      2^16      |  16.398 us |       1.70% |  16.444 us |       1.68% |    0.045 us |   0.28% |   PASS   |
|    I32     |     I128     |      I32      |      2^20      |  39.379 us |       1.37% |  39.078 us |       1.56% |   -0.301 us |  -0.76% |   PASS   |
|    I32     |     I128     |      I32      |      2^24      | 373.681 us |       0.64% | 368.197 us |       0.67% |   -5.484 us |  -1.47% |   FAIL   |
|    I32     |     I128     |      I32      |      2^28      |   5.711 ms |       0.18% |   5.622 ms |       0.17% |  -89.849 us |  -1.57% |   FAIL   |
|    I64     |      I8      |      I32      |      2^16      |  10.883 us |       2.11% |  11.362 us |       2.52% |    0.479 us |   4.41% |   FAIL   |
|    I64     |      I8      |      I32      |      2^20      |  19.957 us |       1.49% |  20.747 us |       1.46% |    0.790 us |   3.96% |   FAIL   |
|    I64     |      I8      |      I32      |      2^24      | 129.393 us |       0.83% | 135.728 us |       1.45% |    6.336 us |   4.90% |   FAIL   |
|    I64     |      I8      |      I32      |      2^28      |   1.735 ms |       0.59% |   1.818 ms |       0.67% |   82.961 us |   4.78% |   FAIL   |
|    I64     |     I16      |      I32      |      2^16      |  11.415 us |       2.13% |  11.791 us |       2.22% |    0.376 us |   3.29% |   FAIL   |
|    I64     |     I16      |      I32      |      2^20      |  21.561 us |       1.87% |  21.975 us |       1.69% |    0.413 us |   1.92% |   FAIL   |
|    I64     |     I16      |      I32      |      2^24      | 143.741 us |       1.47% | 147.695 us |       1.39% |    3.954 us |   2.75% |   FAIL   |
|    I64     |     I16      |      I32      |      2^28      |   2.134 ms |       0.56% |   2.144 ms |       0.56% |    9.955 us |   0.47% |   PASS   |
|    I64     |     I32      |      I32      |      2^16      |  11.649 us |       2.49% |  12.070 us |       2.48% |    0.421 us |   3.61% |   FAIL   |
|    I64     |     I32      |      I32      |      2^20      |  23.008 us |       1.30% |  23.528 us |       1.22% |    0.520 us |   2.26% |   FAIL   |
|    I64     |     I32      |      I32      |      2^24      | 170.950 us |       1.05% | 172.730 us |       1.31% |    1.780 us |   1.04% |   PASS   |
|    I64     |     I32      |      I32      |      2^28      |   2.535 ms |       0.50% |   2.553 ms |       0.50% |   18.540 us |   0.73% |   FAIL   |
|    I64     |     I64      |      I32      |      2^16      |  12.251 us |       1.69% |  12.467 us |       2.79% |    0.216 us |   1.76% |   FAIL   |
|    I64     |     I64      |      I32      |      2^20      |  26.477 us |       1.29% |  26.050 us |       1.29% |   -0.428 us |  -1.62% |   FAIL   |
|    I64     |     I64      |      I32      |      2^24      | 242.311 us |       0.88% | 238.493 us |       0.91% |   -3.818 us |  -1.58% |   FAIL   |
|    I64     |     I64      |      I32      |      2^28      |   3.655 ms |       0.33% |   3.587 ms |       0.41% |  -67.808 us |  -1.86% |   FAIL   |
|    I64     |     I128     |      I32      |      2^16      |  16.149 us |       1.90% |  16.642 us |       1.41% |    0.493 us |   3.05% |   FAIL   |
|    I64     |     I128     |      I32      |      2^20      |  43.487 us |       2.40% |  44.969 us |       2.01% |    1.482 us |   3.41% |   FAIL   |
|    I64     |     I128     |      I32      |      2^24      | 422.304 us |       0.60% | 428.711 us |       0.50% |    6.408 us |   1.52% |   FAIL   |
|    I64     |     I128     |      I32      |      2^28      |   6.511 ms |       0.17% |   6.608 ms |       0.13% |   97.303 us |   1.49% |   FAIL   |
|    I128    |      I8      |      I32      |      2^16      |  11.983 us |       1.98% |  12.398 us |       2.23% |    0.415 us |   3.46% |   FAIL   |
|    I128    |      I8      |      I32      |      2^20      |  28.292 us |       1.58% |  28.149 us |       1.53% |   -0.144 us |  -0.51% |   PASS   |
|    I128    |      I8      |      I32      |      2^24      | 204.049 us |       1.22% | 206.439 us |       1.32% |    2.390 us |   1.17% |   PASS   |
|    I128    |      I8      |      I32      |      2^28      |   3.016 ms |       0.50% |   3.031 ms |       0.50% |   15.140 us |   0.50% |   FAIL   |
|    I128    |     I16      |      I32      |      2^16      |  12.121 us |       2.44% |  12.411 us |       2.24% |    0.290 us |   2.39% |   FAIL   |
|    I128    |     I16      |      I32      |      2^20      |  27.993 us |       1.68% |  28.253 us |       2.12% |    0.260 us |   0.93% |   PASS   |
|    I128    |     I16      |      I32      |      2^24      | 220.695 us |       1.05% | 222.751 us |       1.13% |    2.057 us |   0.93% |   PASS   |
|    I128    |     I16      |      I32      |      2^28      |   3.269 ms |       0.50% |   3.284 ms |       0.50% |   14.860 us |   0.45% |   PASS   |
|    I128    |     I32      |      I32      |      2^16      |  12.039 us |       1.94% |  12.249 us |       2.23% |    0.210 us |   1.75% |   PASS   |
|    I128    |     I32      |      I32      |      2^20      |  29.717 us |       1.95% |  30.721 us |       2.24% |    1.004 us |   3.38% |   FAIL   |
|    I128    |     I32      |      I32      |      2^24      | 257.654 us |       1.04% | 259.204 us |       1.05% |    1.550 us |   0.60% |   PASS   |
|    I128    |     I32      |      I32      |      2^28      |   3.882 ms |       0.44% |   3.898 ms |       0.42% |   15.911 us |   0.41% |   PASS   |
|    I128    |     I64      |      I32      |      2^16      |  12.756 us |       2.25% |  13.013 us |       2.15% |    0.258 us |   2.02% |   PASS   |
|    I128    |     I64      |      I32      |      2^20      |  35.225 us |       1.77% |  35.005 us |       1.41% |   -0.220 us |  -0.62% |   PASS   |
|    I128    |     I64      |      I32      |      2^24      | 321.544 us |       0.81% | 322.065 us |       0.81% |    0.521 us |   0.16% |   PASS   |
|    I128    |     I64      |      I32      |      2^28      |   4.924 ms |       0.22% |   4.931 ms |       0.25% |    7.246 us |   0.15% |   PASS   |
|    I128    |     I128     |      I32      |      2^16      |  17.423 us |       1.72% |  18.420 us |       1.80% |    0.997 us |   5.72% |   FAIL   |
|    I128    |     I128     |      I32      |      2^20      |  49.967 us |       1.88% |  50.208 us |       1.76% |    0.241 us |   0.48% |   PASS   |
|    I128    |     I128     |      I32      |      2^24      | 495.701 us |       0.52% | 495.974 us |       0.54% |    0.273 us |   0.05% |   PASS   |
|    I128    |     I128     |      I32      |      2^28      |   7.645 ms |       0.15% |   7.642 ms |       0.12% |   -3.353 us |  -0.04% |   PASS   |
|    F32     |      I8      |      I32      |      2^16      |  10.481 us |       2.54% |  11.006 us |       2.64% |    0.525 us |   5.01% |   FAIL   |
|    F32     |      I8      |      I32      |      2^20      |  16.745 us |       1.61% |  17.475 us |       1.40% |    0.730 us |   4.36% |   FAIL   |
|    F32     |      I8      |      I32      |      2^24      |  91.597 us |       1.06% |  99.123 us |       1.50% |    7.526 us |   8.22% |   FAIL   |
|    F32     |      I8      |      I32      |      2^28      |   1.175 ms |       0.69% |   1.296 ms |       0.70% |  121.575 us |  10.35% |   FAIL   |
|    F32     |     I16      |      I32      |      2^16      |  11.356 us |       2.26% |  12.059 us |       1.84% |    0.703 us |   6.19% |   FAIL   |
|    F32     |     I16      |      I32      |      2^20      |  17.067 us |       1.24% |  18.393 us |       1.21% |    1.325 us |   7.77% |   FAIL   |
|    F32     |     I16      |      I32      |      2^24      | 100.878 us |       1.15% | 109.841 us |       1.60% |    8.963 us |   8.89% |   FAIL   |
|    F32     |     I16      |      I32      |      2^28      |   1.405 ms |       0.76% |   1.468 ms |       0.84% |   62.804 us |   4.47% |   FAIL   |
|    F32     |     I32      |      I32      |      2^16      |  12.033 us |       1.86% |  12.349 us |       2.02% |    0.316 us |   2.63% |   FAIL   |
|    F32     |     I32      |      I32      |      2^20      |  18.856 us |       1.47% |  19.483 us |       1.69% |    0.627 us |   3.33% |   FAIL   |
|    F32     |     I32      |      I32      |      2^24      | 129.849 us |       1.06% | 131.465 us |       1.24% |    1.616 us |   1.24% |   FAIL   |
|    F32     |     I32      |      I32      |      2^28      |   1.908 ms |       0.58% |   1.927 ms |       0.60% |   19.268 us |   1.01% |   FAIL   |
|    F32     |     I64      |      I32      |      2^16      |  12.276 us |       1.83% |  12.812 us |       2.05% |    0.535 us |   4.36% |   FAIL   |
|    F32     |     I64      |      I32      |      2^20      |  22.874 us |       1.27% |  23.609 us |       1.15% |    0.735 us |   3.21% |   FAIL   |
|    F32     |     I64      |      I32      |      2^24      | 197.864 us |       0.89% | 210.559 us |       0.77% |   12.695 us |   6.42% |   FAIL   |
|    F32     |     I64      |      I32      |      2^28      |   2.942 ms |       0.50% |   3.150 ms |       0.50% |  207.668 us |   7.06% |   FAIL   |
|    F32     |     I128     |      I32      |      2^16      |  16.330 us |       1.82% |  16.417 us |       1.78% |    0.087 us |   0.53% |   PASS   |
|    F32     |     I128     |      I32      |      2^20      |  39.346 us |       1.62% |  39.019 us |       1.62% |   -0.327 us |  -0.83% |   PASS   |
|    F32     |     I128     |      I32      |      2^24      | 373.881 us |       0.64% | 368.136 us |       0.67% |   -5.745 us |  -1.54% |   FAIL   |
|    F32     |     I128     |      I32      |      2^28      |   5.712 ms |       0.16% |   5.617 ms |       0.18% |  -95.281 us |  -1.67% |   FAIL   |
|    F64     |      I8      |      I32      |      2^16      |  10.701 us |       2.38% |  11.214 us |       2.31% |    0.513 us |   4.80% |   FAIL   |
|    F64     |      I8      |      I32      |      2^20      |  20.530 us |       1.45% |  20.469 us |       1.49% |   -0.060 us |  -0.29% |   PASS   |
|    F64     |      I8      |      I32      |      2^24      | 128.157 us |       0.75% | 135.480 us |       1.45% |    7.323 us |   5.71% |   FAIL   |
|    F64     |      I8      |      I32      |      2^28      |   1.724 ms |       0.59% |   1.813 ms |       0.65% |   88.194 us |   5.11% |   FAIL   |
|    F64     |     I16      |      I32      |      2^16      |  11.438 us |       2.45% |  11.604 us |       2.39% |    0.166 us |   1.45% |   PASS   |
|    F64     |     I16      |      I32      |      2^20      |  20.746 us |       1.34% |  22.009 us |       1.70% |    1.263 us |   6.09% |   FAIL   |
|    F64     |     I16      |      I32      |      2^24      | 138.859 us |       1.39% | 147.246 us |       1.47% |    8.387 us |   6.04% |   FAIL   |
|    F64     |     I16      |      I32      |      2^28      |   2.041 ms |       0.55% |   2.143 ms |       0.56% |  101.248 us |   4.96% |   FAIL   |
|    F64     |     I32      |      I32      |      2^16      |  11.852 us |       1.97% |  12.062 us |       2.29% |    0.210 us |   1.77% |   PASS   |
|    F64     |     I32      |      I32      |      2^20      |  23.154 us |       1.39% |  23.642 us |       1.40% |    0.487 us |   2.10% |   FAIL   |
|    F64     |     I32      |      I32      |      2^24      | 170.927 us |       1.05% | 172.508 us |       1.31% |    1.581 us |   0.92% |   PASS   |
|    F64     |     I32      |      I32      |      2^28      |   2.532 ms |       0.50% |   2.551 ms |       0.50% |   18.391 us |   0.73% |   FAIL   |
|    F64     |     I64      |      I32      |      2^16      |  12.621 us |       2.19% |  12.519 us |       2.63% |   -0.102 us |  -0.81% |   PASS   |
|    F64     |     I64      |      I32      |      2^20      |  26.453 us |       1.18% |  25.798 us |       1.20% |   -0.655 us |  -2.48% |   FAIL   |
|    F64     |     I64      |      I32      |      2^24      | 241.999 us |       0.89% | 237.993 us |       0.92% |   -4.006 us |  -1.66% |   FAIL   |
|    F64     |     I64      |      I32      |      2^28      |   3.651 ms |       0.38% |   3.582 ms |       0.42% |  -68.694 us |  -1.88% |   FAIL   |
|    F64     |     I128     |      I32      |      2^16      |  16.357 us |       1.70% |  16.682 us |       1.67% |    0.325 us |   1.99% |   FAIL   |
|    F64     |     I128     |      I32      |      2^20      |  43.578 us |       2.11% |  44.929 us |       1.83% |    1.350 us |   3.10% |   FAIL   |
|    F64     |     I128     |      I32      |      2^24      | 421.559 us |       0.60% | 428.867 us |       0.53% |    7.308 us |   1.73% |   FAIL   |
|    F64     |     I128     |      I32      |      2^28      |   6.502 ms |       0.15% |   6.611 ms |       0.11% |  108.638 us |   1.67% |   FAIL   |
|    C64     |      I8      |      I32      |      2^16      |  11.127 us |       2.35% |  11.336 us |       2.57% |    0.209 us |   1.88% |   PASS   |
|    C64     |      I8      |      I32      |      2^20      |  20.410 us |       1.46% |  20.626 us |       1.34% |    0.216 us |   1.06% |   PASS   |
|    C64     |      I8      |      I32      |      2^24      | 129.988 us |       0.82% | 135.220 us |       1.43% |    5.231 us |   4.02% |   FAIL   |
|    C64     |      I8      |      I32      |      2^28      |   1.735 ms |       0.60% |   1.812 ms |       0.67% |   76.373 us |   4.40% |   FAIL   |
|    C64     |     I16      |      I32      |      2^16      |  11.347 us |       2.12% |  11.853 us |       1.96% |    0.507 us |   4.47% |   FAIL   |
|    C64     |     I16      |      I32      |      2^20      |  20.614 us |       1.29% |  21.199 us |       1.42% |    0.585 us |   2.84% |   FAIL   |
|    C64     |     I16      |      I32      |      2^24      | 138.900 us |       1.39% | 141.278 us |       1.61% |    2.378 us |   1.71% |   FAIL   |
|    C64     |     I16      |      I32      |      2^28      |   2.043 ms |       0.55% |   2.058 ms |       0.61% |   14.323 us |   0.70% |   FAIL   |
|    C64     |     I32      |      I32      |      2^16      |  11.660 us |       2.21% |  12.120 us |       2.37% |    0.460 us |   3.95% |   FAIL   |
|    C64     |     I32      |      I32      |      2^20      |  22.882 us |       1.24% |  23.558 us |       1.26% |    0.676 us |   2.96% |   FAIL   |
|    C64     |     I32      |      I32      |      2^24      | 170.903 us |       1.09% | 172.673 us |       1.30% |    1.770 us |   1.04% |   PASS   |
|    C64     |     I32      |      I32      |      2^28      |   2.534 ms |       0.50% |   2.552 ms |       0.50% |   18.336 us |   0.72% |   FAIL   |
|    C64     |     I64      |      I32      |      2^16      |  12.142 us |       2.32% |  12.606 us |       2.51% |    0.464 us |   3.83% |   FAIL   |
|    C64     |     I64      |      I32      |      2^20      |  25.595 us |       1.18% |  25.937 us |       1.07% |    0.342 us |   1.34% |   FAIL   |
|    C64     |     I64      |      I32      |      2^24      | 237.445 us |       0.92% | 238.259 us |       0.93% |    0.815 us |   0.34% |   PASS   |
|    C64     |     I64      |      I32      |      2^28      |   3.580 ms |       0.39% |   3.587 ms |       0.40% |    7.305 us |   0.20% |   PASS   |
|    C64     |     I128     |      I32      |      2^16      |  16.124 us |       1.64% |  16.761 us |       1.68% |    0.637 us |   3.95% |   FAIL   |
|    C64     |     I128     |      I32      |      2^20      |  43.668 us |       2.20% |  45.047 us |       1.96% |    1.379 us |   3.16% |   FAIL   |
|    C64     |     I128     |      I32      |      2^24      | 422.962 us |       0.61% | 429.436 us |       0.51% |    6.475 us |   1.53% |   FAIL   |
|    C64     |     I128     |      I32      |      2^28      |   6.518 ms |       0.16% |   6.619 ms |       0.13% |  101.529 us |   1.56% |   FAIL   |
