### PR TITLE
[DRAFT] This PR adds a prototypical implementation for an atomics-based, unstable `DeviceSelect`

### DIFF
--- a/cub/cub/agent/agent_select_if.cuh
+++ b/cub/cub/agent/agent_select_if.cuh
@@ -498,7 +498,7 @@ struct AgentSelectIf
     OffsetT (&selection_flags)[ITEMS_PER_THREAD],
     constant_t<USE_DISCONTINUITY> /*select_method*/)
   {
-    if (IS_FIRST_TILE && streaming_context.is_first_partition())
+    if ((tile_offset == 0 || IS_FIRST_TILE) && streaming_context.is_first_partition())
     {
       __syncthreads();
 

--- a/cub/cub/device/dispatch/dispatch_select_if.cuh
+++ b/cub/cub/device/dispatch/dispatch_select_if.cuh
@@ -450,7 +450,8 @@ struct DispatchSelectIf
 
   using streaming_context_t = detail::select::streaming_context_t<num_total_items_t, may_require_streaming>;
 
-  using ScanTileStateT = ScanTileState<per_partition_offset_t>;
+  // using ScanTileStateT = ScanTileState<per_partition_offset_t>;
+  using ScanTileStateT = detail::AtomicsBasedTileState<per_partition_offset_t>;
 
   static constexpr int INIT_KERNEL_THREADS = 128;
 

--- a/cub/test/catch2_test_device_select_if.cu
+++ b/cub/test/catch2_test_device_select_if.cu
@@ -93,80 +93,62 @@ using all_types =
                  long2,
                  c2h::custom_type_t<c2h::less_comparable_t, c2h::equal_comparable_t>>;
 
-using types =
-  c2h::type_list<std::uint8_t,
-                 std::uint32_t>;
+using types = c2h::type_list<std::uint8_t, std::uint32_t>;
 
-template<typename T>
-void verify_results(c2h::host_vector<T> &expected_data, c2h::device_vector<T> &test_results){
-  // Ensure that we created the correct output
-  REQUIRE(test_results.size() == expected_data.size());
-
-  thrust::sort(expected_data.begin(), expected_data.end());
-  thrust::sort(test_results.begin(), test_results.end());
-
-  // int num_selected_out = static_cast<int>(expected_data.size());
-  // for(int i = 0; i < num_selected_out; ++i)
-  // {
-  //   if(expected_data[i] != test_results[i]){
-  //     std::cout << "i: " << i << " expected_data[i]: " << expected_data[i] << " out[i]: " << test_results[i] << std::endl;
-  //     for(int j = i > 5?i-5:0; j < num_selected_out && j < i + 5; ++j)
-  //     {
-  //       std::cout << "i: " << j << " expected_data[i]: " << expected_data[j] << " out[i]: " << test_results[j] << std::endl;
-  //     }
-  //     break;
-  //   }
-  // }
-  REQUIRE(expected_data == test_results);
-}
-template<typename T>
-void verify_results(c2h::device_vector<T> &expected_data, c2h::device_vector<T> &test_results){
-  // Ensure that we created the correct output
-  REQUIRE(test_results.size() == expected_data.size());
-
-  thrust::sort(expected_data.begin(), expected_data.end());
-  thrust::sort(test_results.begin(), test_results.end());
-  
-  // int num_selected_out = static_cast<int>(expected_data.size());
-  // for(int i = 0; i < num_selected_out; ++i)
-  // {
-  //   if(expected_data[i] != test_results[i]){
-  //     std::cout << "i: " << i << " expected_data[i]: " << expected_data[i] << " out[i]: " << test_results[i] << std::endl;
-  //     for(int j = i > 5?i-5:0; j < num_selected_out && j < i + 5; ++j)
-  //     {
-  //       std::cout << "i: " << j << " expected_data[i]: " << expected_data[j] << " out[i]: " << test_results[j] << std::endl;
-  //     }
-  //     break;
-  //   }
-  // }
-  REQUIRE(expected_data == test_results);
-}
-
-#if false
-C2H_TEST("DeviceSelect::If can run with empty input", "[device][select_if]", types)
+template <typename T>
+void verify_results(c2h::host_vector<T>& expected_data, c2h::device_vector<T>& test_results)
 {
-  using type = typename c2h::get<0, TestType>;
+  // Ensure that we created the correct output
+  REQUIRE(test_results.size() == expected_data.size());
 
-  constexpr int num_items = 0;
-  c2h::device_vector<type> in(num_items);
-  c2h::device_vector<type> out(num_items);
+  thrust::sort(expected_data.begin(), expected_data.end());
+  thrust::sort(test_results.begin(), test_results.end());
 
-  // Needs to be device accessible
-  c2h::device_vector<int> num_selected_out(1, 42);
-  int* d_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
-
-  select_if(in.begin(), out.begin(), d_num_selected_out, num_items, always_true_t{});
-
-  REQUIRE(num_selected_out[0] == 0);
+  // int num_selected_out = static_cast<int>(expected_data.size());
+  // for(int i = 0; i < num_selected_out; ++i)
+  // {
+  //   if(expected_data[i] != test_results[i]){
+  //     std::cout << "i: " << i << " expected_data[i]: " << expected_data[i] << " out[i]: " << test_results[i] <<
+  //     std::endl; for(int j = i > 5?i-5:0; j < num_selected_out && j < i + 5; ++j)
+  //     {
+  //       std::cout << "i: " << j << " expected_data[i]: " << expected_data[j] << " out[i]: " << test_results[j] <<
+  //       std::endl;
+  //     }
+  //     break;
+  //   }
+  // }
+  REQUIRE(expected_data == test_results);
 }
+template <typename T>
+void verify_results(c2h::device_vector<T>& expected_data, c2h::device_vector<T>& test_results)
+{
+  // Ensure that we created the correct output
+  REQUIRE(test_results.size() == expected_data.size());
 
-#endif
+  thrust::sort(expected_data.begin(), expected_data.end());
+  thrust::sort(test_results.begin(), test_results.end());
+
+  // int num_selected_out = static_cast<int>(expected_data.size());
+  // for(int i = 0; i < num_selected_out; ++i)
+  // {
+  //   if(expected_data[i] != test_results[i]){
+  //     std::cout << "i: " << i << " expected_data[i]: " << expected_data[i] << " out[i]: " << test_results[i] <<
+  //     std::endl; for(int j = i > 5?i-5:0; j < num_selected_out && j < i + 5; ++j)
+  //     {
+  //       std::cout << "i: " << j << " expected_data[i]: " << expected_data[j] << " out[i]: " << test_results[j] <<
+  //       std::endl;
+  //     }
+  //     break;
+  //   }
+  // }
+  REQUIRE(expected_data == test_results);
+}
 
 C2H_TEST("DeviceSelect::If handles all matched", "[device][select_if]", types)
 {
   using type = typename c2h::get<0, TestType>;
 
-  const int num_items = GENERATE_COPY(take(2, random(1, 3000)));
+  const int num_items = GENERATE_COPY(take(2, random(1, 20000000)));
   c2h::device_vector<type> in(num_items);
   c2h::device_vector<type> out(num_items, 42);
   c2h::gen(C2H_SEED(2), in);
@@ -180,50 +162,6 @@ C2H_TEST("DeviceSelect::If handles all matched", "[device][select_if]", types)
   REQUIRE(num_selected_out[0] == num_items);
   verify_results(in, out);
 }
-
-#if false
-C2H_TEST("DeviceSelect::If handles no matched", "[device][select_if]", types)
-{
-  using type = typename c2h::get<0, TestType>;
-
-  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
-  c2h::device_vector<type> in(num_items);
-  c2h::device_vector<type> out(0);
-  c2h::gen(C2H_SEED(2), in);
-
-  // Needs to be device accessible
-  c2h::device_vector<int> num_selected_out(1, 0);
-  int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
-
-  select_if(in.begin(), out.begin(), d_first_num_selected_out, num_items, always_false_t{});
-
-  REQUIRE(num_selected_out[0] == 0);
-}
-
-C2H_TEST("DeviceSelect::If does not change input", "[device][select_if]", types)
-{
-  using type = typename c2h::get<0, TestType>;
-
-  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
-  c2h::device_vector<type> in(num_items);
-  c2h::device_vector<type> out(num_items);
-  c2h::gen(C2H_SEED(2), in);
-
-  // just pick one of the input elements as boundary
-  less_than_t<type> le{in[num_items / 2]};
-
-  // Needs to be device accessible
-  c2h::device_vector<int> num_selected_out(1, 0);
-  int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
-
-  // copy input first
-  c2h::device_vector<type> reference = in;
-
-  select_if(in.begin(), out.begin(), d_first_num_selected_out, num_items, le);
-
-  REQUIRE(reference == in);
-}
-#endif
 
 C2H_TEST("DeviceSelect::If is stable", "[device][select_if]")
 {
@@ -253,239 +191,6 @@ C2H_TEST("DeviceSelect::If is stable", "[device][select_if]")
 
   out.resize(num_selected_out[0]);
   reference.resize(num_selected_out[0]);
-  // REQUIRE(reference == out);
-  
+
   verify_results(reference, out);
 }
-
-// C2H_TEST("DeviceSelect::If works with iterators", "[device][select_if]", all_types)
-// {
-//   using type = typename c2h::get<0, TestType>;
-
-//   const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
-//   c2h::device_vector<type> in(num_items);
-//   c2h::device_vector<type> out(num_items);
-//   c2h::gen(C2H_SEED(2), in);
-
-//   // just pick one of the input elements as boundary
-//   less_than_t<type> le{in[num_items / 2]};
-
-//   // Needs to be device accessible
-//   c2h::device_vector<int> num_selected_out(1, 0);
-//   int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
-
-//   select_if(in.begin(), out.begin(), d_first_num_selected_out, num_items, le);
-
-//   const auto boundary = out.begin() + num_selected_out[0];
-//   REQUIRE(thrust::all_of(c2h::device_policy, out.begin(), boundary, le));
-//   REQUIRE(thrust::all_of(c2h::device_policy, boundary, out.end(), equal_to_default_t{}));
-// }
-
-// C2H_TEST("DeviceSelect::If works with pointers", "[device][select_if]", types)
-// {
-//   using type = typename c2h::get<0, TestType>;
-
-//   const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
-//   c2h::device_vector<type> in(num_items);
-//   c2h::device_vector<type> out(num_items);
-//   c2h::gen(C2H_SEED(2), in);
-
-//   // just pick one of the input elements as boundary
-//   less_than_t<type> le{in[num_items / 2]};
-
-//   // Needs to be device accessible
-//   c2h::device_vector<int> num_selected_out(1, 0);
-//   int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
-
-//   select_if(
-//     thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), d_first_num_selected_out, num_items, le);
-
-//   const auto boundary = out.begin() + num_selected_out[0];
-//   REQUIRE(thrust::all_of(c2h::device_policy, out.begin(), boundary, le));
-//   REQUIRE(thrust::all_of(c2h::device_policy, boundary, out.end(), equal_to_default_t{}));
-// }
-
-// C2H_TEST("DeviceSelect::If works in place", "[device][select_if]", types)
-// {
-//   using type = typename c2h::get<0, TestType>;
-
-//   const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
-//   c2h::device_vector<type> in(num_items);
-//   c2h::gen(C2H_SEED(2), in);
-
-//   // just pick one of the input elements as boundary
-//   less_than_t<type> le{in[num_items / 2]};
-
-//   // Needs to be device accessible
-//   c2h::device_vector<int> num_selected_out(1, 0);
-//   int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
-
-//   // Ensure that we create the same output as std
-//   c2h::host_vector<type> reference = in;
-//   std::stable_partition(reference.begin(), reference.end(), le);
-
-//   select_if(in.begin(), d_first_num_selected_out, num_items, le);
-
-//   in.resize(num_selected_out[0]);
-//   reference.resize(num_selected_out[0]);
-//   REQUIRE(reference == in);
-// }
-
-template <class T>
-struct convertible_from_T
-{
-  T val_;
-
-  convertible_from_T() = default;
-  __host__ __device__ convertible_from_T(const T& val) noexcept
-      : val_(val)
-  {}
-  __host__ __device__ convertible_from_T& operator=(const T& val) noexcept
-  {
-    val_ = val;
-  }
-  // Converting back to T helps satisfy all the machinery that T supports
-  __host__ __device__ operator T() const noexcept
-  {
-    return val_;
-  }
-};
-
-// C2H_TEST("DeviceSelect::If works with a different output type", "[device][select_if]")
-// {
-//   using type = c2h::custom_type_t<c2h::less_comparable_t, c2h::equal_comparable_t>;
-
-//   const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
-//   c2h::device_vector<type> in(num_items);
-//   c2h::device_vector<convertible_from_T<type>> out(num_items);
-//   c2h::gen(C2H_SEED(2), in);
-
-//   // just pick one of the input elements as boundary
-//   less_than_t<type> le{in[num_items / 2]};
-
-//   // Needs to be device accessible
-//   c2h::device_vector<int> num_selected_out(1, 0);
-//   int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
-
-//   select_if(in.begin(), out.begin(), d_first_num_selected_out, num_items, le);
-
-//   const auto boundary = out.begin() + num_selected_out[0];
-//   REQUIRE(thrust::all_of(c2h::device_policy, out.begin(), boundary, le));
-//   REQUIRE(thrust::all_of(c2h::device_policy, boundary, out.end(), equal_to_default_t{}));
-// }
-
-// C2H_TEST("DeviceSelect::If works for very large number of items", "[device][select_if]")
-// try
-// {
-//   using type     = std::int64_t;
-//   using offset_t = std::int64_t;
-
-//   // The partition size (the maximum number of items processed by a single kernel invocation) is an important boundary
-//   constexpr auto max_partition_size = static_cast<offset_t>(::cuda::std::numeric_limits<std::int32_t>::max());
-
-//   offset_t num_items = GENERATE_COPY(
-//     values({
-//       offset_t{2} * max_partition_size + offset_t{20000000}, // 3 partitions
-//       offset_t{2} * max_partition_size, // 2 partitions
-//       max_partition_size + offset_t{1}, // 2 partitions
-//       max_partition_size, // 1 partitions
-//       max_partition_size - offset_t{1} // 1 partitions
-//     }),
-//     take(2, random(max_partition_size - offset_t{1000000}, max_partition_size + offset_t{1000000})));
-
-//   // Input
-//   auto in = thrust::make_counting_iterator(static_cast<type>(0));
-
-//   // Needs to be device accessible
-//   c2h::device_vector<offset_t> num_selected_out(1, 0);
-//   offset_t* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
-
-//   // Run test
-//   constexpr offset_t match_every_nth = 1000000;
-//   offset_t expected_num_copied       = (num_items + match_every_nth - offset_t{1}) / match_every_nth;
-//   c2h::device_vector<type> out(expected_num_copied);
-//   select_if(
-//     in, out.begin(), d_first_num_selected_out, num_items, mod_n<offset_t>{static_cast<offset_t>(match_every_nth)});
-
-//   // Ensure that we created the correct output
-//   REQUIRE(num_selected_out[0] == expected_num_copied);
-//   auto expected_out_it =
-//     thrust::make_transform_iterator(in, multiply_n<offset_t>{static_cast<offset_t>(match_every_nth)});
-//   bool all_results_correct = thrust::equal(out.cbegin(), out.cend(), expected_out_it);
-//   REQUIRE(all_results_correct == true);
-// }
-// catch (std::bad_alloc&)
-// {
-//   // Exceeding memory is not a failure.
-// }
-
-// C2H_TEST("DeviceSelect::If works for very large number of output items", "[device][select_if]")
-// try
-// {
-//   using type     = std::uint8_t;
-//   using offset_t = std::int64_t;
-
-//   // The partition size (the maximum number of items processed by a single kernel invocation) is an important boundary
-//   constexpr auto max_partition_size = static_cast<offset_t>(::cuda::std::numeric_limits<std::int32_t>::max());
-
-//   offset_t num_items = GENERATE_COPY(
-//     values({
-//       offset_t{2} * max_partition_size + offset_t{20000000}, // 3 partitions
-//       offset_t{2} * max_partition_size, // 2 partitions
-//       max_partition_size + offset_t{1}, // 2 partitions
-//       max_partition_size, // 1 partitions
-//       max_partition_size - offset_t{1} // 1 partitions
-//     }),
-//     take(2, random(max_partition_size - offset_t{1000000}, max_partition_size + offset_t{1000000})));
-
-//   // Prepare input iterator: it[i] = (i%mod)+(i/div)
-//   static constexpr offset_t mod = 200;
-//   static constexpr offset_t div = 1000000000;
-//   auto in                       = thrust::make_transform_iterator(
-//     thrust::make_counting_iterator(offset_t{0}), modx_and_add_divy<offset_t, type>{mod, div});
-
-//   // Prepare output
-//   c2h::device_vector<type> out(num_items);
-
-//   // Needs to be device accessible
-//   c2h::device_vector<offset_t> num_selected_out(1, 0);
-//   offset_t* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
-
-//   // Run test
-//   select_if(in, out.begin(), d_first_num_selected_out, num_items, always_true_t{});
-
-//   // Ensure that we created the correct output
-//   REQUIRE(num_selected_out[0] == num_items);
-//   bool all_results_correct = thrust::equal(out.cbegin(), out.cend(), in);
-//   REQUIRE(all_results_correct == true);
-// }
-// catch (std::bad_alloc&)
-// {
-//   // Exceeding memory is not a failure.
-// }
-
-// C2H_TEST("DeviceSelect::If works with iterators", "[device][select_if]")
-// {
-//   using type = int;
-
-//   const int num_items = 10'000;
-//   c2h::device_vector<type> in(num_items);
-//   thrust::sequence(in.begin(), in.end());
-//   c2h::device_vector<type> out(num_items);
-//   using thrust::placeholders::_1;
-
-//   // select twice, appending the second selection to the first one without bringing the first selection's count to the
-//   // host
-//   c2h::device_vector<int> num_selected_out(2);
-//   select_if(in.begin(), out.begin(), num_selected_out.begin(), num_items, _1 < 1000); // [0;999]
-//   auto output_end = thrust::offset_iterator{out.begin(), num_selected_out.begin()};
-//   select_if(in.begin(), output_end, num_selected_out.begin() + 1, num_items, _1 >= 9000); // [9000;9999]
-
-//   c2h::device_vector<type> expected(2000);
-//   thrust::sequence(expected.begin(), expected.begin() + 1000);
-//   thrust::sequence(expected.begin() + 1000, expected.end(), 9000);
-
-//   out.resize(2000);
-//   REQUIRE(num_selected_out == c2h::device_vector<int>{1000, 1000});
-//   REQUIRE(out == expected);
-// }


### PR DESCRIPTION
## Description

This is only a prototype. The PR has modified a few of the tests to accept unstable results from `DeviceSelect`.

### Preliminary performance results

#### `DeviceSelect::If` on H100




Elements | %Diff Range | Max Speedup | Status Summary
-- | -- | -- | --
2^16 | -3.81% to +8.92% | 1.04× | SAME/SLOW
2^20 | -14.19% to +4.76% | 1.17× | FAST/SAME
2^24 | -27.65% to +1.09% | 1.38× | FAST
2^28 | -36.41% to -8.61% | 1.57× | FAST


#### `DeviceSelect::Flagged` on H100

Elements | %Diff Range | Max Speedup | Most Frequent Status
-- | -- | -- | --
2^16 | -0.93% to 8.08% | 1.01× | SAME/SLOW
2^20 | -14.19% to 3.53% | 1.16× | SAME/FAST
2^24 | -20.82% to 2.63% | 1.26× | FAST
2^28 | -22.24% to 0.00% | 1.29× | FAST

#### `DeviceSelect::Unique` on H100

Elements | %Diff Range | Max Speedup | Status
-- | -- | -- | --
2^16 | -5.29% to +5.64% | 1.06× | SAME
2^20 | -14.18% to +5.44% | 1.17× | FAST
2^24 | -30.72% to +0.36% | 1.44× | FAST
2^28 | -30.27% to +5.64% | 1.43× | FAST





<details>
<summary>
Comparing cub.bench.select.if.base decoupled look-back versus atomics-based on H100
</summary>


|  T{ct}  |  OffsetT{ct}  |  InPlace{ct}  |  Elements{io}  |  Entropy  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|---------------|----------------|-----------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I64      |     false     |      2^16      |     1     |  10.374 us |       4.88% |  10.279 us |       5.66% |   -0.095 us |  -0.92% |   SAME   |
|   I8    |      I64      |     false     |      2^24      |     1     |  53.881 us |       1.37% |  44.524 us |       1.13% |   -9.357 us | -17.37% |   FAST   |
|   I8    |      I64      |     false     |      2^28      |     1     | 722.075 us |       0.50% | 550.260 us |       0.27% | -171.815 us | -23.79% |   FAST   |
|   I8    |      I64      |     false     |      2^16      |   0.544   |  10.054 us |       6.61% |  10.009 us |       5.23% |   -0.045 us |  -0.45% |   SAME   |
|   I8    |      I64      |     false     |      2^20      |   0.544   |  12.458 us |       2.79% |  11.032 us |       3.01% |   -1.426 us | -11.45% |   FAST   |
|   I8    |      I64      |     false     |      2^24      |   0.544   |  50.381 us |       1.39% |  40.131 us |       1.23% |  -10.250 us | -20.35% |   FAST   |
|   I8    |      I64      |     false     |      2^28      |   0.544   | 668.091 us |       0.47% | 483.382 us |       0.22% | -184.709 us | -27.65% |   FAST   |
|   I8    |      I64      |     false     |      2^16      |     0     |   9.974 us |       5.24% |   9.652 us |       5.90% |   -0.322 us |  -3.23% |   SAME   |
|   I8    |      I64      |     false     |      2^20      |     0     |  12.157 us |       4.59% |  10.709 us |       4.99% |   -1.448 us | -11.91% |   FAST   |
|   I8    |      I64      |     false     |      2^24      |     0     |  44.086 us |       1.29% |  33.773 us |       1.49% |  -10.313 us | -23.39% |   FAST   |
|   I8    |      I64      |     false     |      2^28      |     0     | 546.405 us |       0.50% | 376.781 us |       0.45% | -169.624 us | -31.04% |   FAST   |
|   I16   |      I64      |     false     |      2^16      |     1     |  10.479 us |       3.55% |  10.379 us |       4.11% |   -0.099 us |  -0.95% |   SAME   |
|   I16   |      I64      |     false     |      2^20      |     1     |  13.606 us |       4.46% |  12.265 us |       5.04% |   -1.341 us |  -9.86% |   FAST   |
|   I16   |      I64      |     false     |      2^24      |     1     |  64.206 us |       3.27% |  49.880 us |       1.40% |  -14.326 us | -22.31% |   FAST   |
|   I16   |      I64      |     false     |      2^28      |     1     | 880.632 us |       1.46% | 651.506 us |       1.91% | -229.126 us | -26.02% |   FAST   |
|   I16   |      I64      |     false     |      2^16      |   0.544   |  10.365 us |       2.79% |  10.227 us |       4.16% |   -0.138 us |  -1.33% |   SAME   |
|   I16   |      I64      |     false     |      2^20      |   0.544   |  13.634 us |       4.50% |  12.349 us |       5.17% |   -1.284 us |  -9.42% |   FAST   |
|   I16   |      I64      |     false     |      2^24      |   0.544   |  57.175 us |       2.84% |  45.903 us |       1.38% |  -11.272 us | -19.71% |   FAST   |
|   I16   |      I64      |     false     |      2^28      |   0.544   | 717.528 us |       1.50% | 539.339 us |       2.29% | -178.189 us | -24.83% |   FAST   |
|   I16   |      I64      |     false     |      2^16      |     0     |  10.198 us |       3.22% |  10.077 us |       4.28% |   -0.121 us |  -1.19% |   SAME   |
|   I16   |      I64      |     false     |      2^20      |     0     |  13.249 us |       4.41% |  11.759 us |       5.68% |   -1.489 us | -11.24% |   FAST   |
|   I16   |      I64      |     false     |      2^24      |     0     |  49.461 us |       2.75% |  39.055 us |       1.75% |  -10.406 us | -21.04% |   FAST   |
|   I16   |      I64      |     false     |      2^28      |     0     | 525.848 us |       1.08% | 334.392 us |       2.35% | -191.456 us | -36.41% |   FAST   |
|   I32   |      I64      |     false     |      2^16      |     1     |  10.664 us |       4.78% |  10.459 us |       5.59% |   -0.205 us |  -1.92% |   SAME   |
|   I32   |      I64      |     false     |      2^20      |     1     |  15.112 us |       2.16% |  14.092 us |       2.67% |   -1.020 us |  -6.75% |   FAST   |
|   I32   |      I64      |     false     |      2^24      |     1     |  89.928 us |       2.84% |  81.303 us |       0.94% |   -8.625 us |  -9.59% |   FAST   |
|   I32   |      I64      |     false     |      2^28      |     1     |   1.328 ms |       0.96% |   1.168 ms |       0.55% | -159.632 us | -12.02% |   FAST   |
|   I32   |      I64      |     false     |      2^16      |   0.544   |  10.753 us |       5.40% |  10.438 us |       5.67% |   -0.315 us |  -2.93% |   SAME   |
|   I32   |      I64      |     false     |      2^20      |   0.544   |  15.053 us |       2.08% |  13.931 us |       2.44% |   -1.122 us |  -7.45% |   FAST   |
|   I32   |      I64      |     false     |      2^24      |   0.544   |  78.454 us |       2.74% |  66.368 us |       1.24% |  -12.086 us | -15.41% |   FAST   |
|   I32   |      I64      |     false     |      2^28      |   0.544   |   1.068 ms |       1.13% | 885.311 us |       0.73% | -183.097 us | -17.14% |   FAST   |
|   I32   |      I64      |     false     |      2^16      |     0     |  10.057 us |       5.58% |   9.928 us |       6.45% |   -0.129 us |  -1.28% |   SAME   |
|   I32   |      I64      |     false     |      2^20      |     0     |  14.288 us |       2.49% |  13.255 us |       2.75% |   -1.033 us |  -7.23% |   FAST   |
|   I32   |      I64      |     false     |      2^24      |     0     |  63.109 us |       2.20% |  57.075 us |       1.31% |   -6.034 us |  -9.56% |   FAST   |
|   I32   |      I64      |     false     |      2^28      |     0     | 650.832 us |       1.49% | 576.676 us |       1.24% |  -74.156 us | -11.39% |   FAST   |
|   I64   |      I64      |     false     |      2^16      |     1     |  10.561 us |       3.23% |  10.676 us |       3.90% |    0.115 us |   1.09% |   SAME   |
|   I64   |      I64      |     false     |      2^20      |     1     |  18.565 us |       3.27% |  17.575 us |       3.83% |   -0.990 us |  -5.33% |   FAST   |
|   I64   |      I64      |     false     |      2^24      |     1     | 165.159 us |       2.23% | 154.374 us |       0.55% |  -10.786 us |  -6.53% |   FAST   |
|   I64   |      I64      |     false     |      2^28      |     1     |   2.549 ms |       0.54% |   2.325 ms |       0.17% | -224.332 us |  -8.80% |   FAST   |
|   I64   |      I64      |     false     |      2^16      |   0.544   |  10.514 us |       3.41% |  10.576 us |       3.01% |    0.062 us |   0.59% |   SAME   |
|   I64   |      I64      |     false     |      2^20      |   0.544   |  18.206 us |       3.38% |  17.116 us |       4.13% |   -1.090 us |  -5.99% |   FAST   |
|   I64   |      I64      |     false     |      2^24      |   0.544   | 137.464 us |       2.79% | 121.202 us |       1.05% |  -16.262 us | -11.83% |   FAST   |
|   I64   |      I64      |     false     |      2^28      |   0.544   |   2.016 ms |       0.79% |   1.757 ms |       0.50% | -258.429 us | -12.82% |   FAST   |
|   I64   |      I64      |     false     |      2^16      |     0     |  10.045 us |       2.98% |  10.401 us |       3.46% |    0.356 us |   3.55% |   SLOW   |
|   I64   |      I64      |     false     |      2^20      |     0     |  16.874 us |       3.61% |  16.120 us |       4.12% |   -0.754 us |  -4.47% |   FAST   |
|   I64   |      I64      |     false     |      2^24      |     0     |  98.405 us |       2.21% |  91.958 us |       0.57% |   -6.447 us |  -6.55% |   FAST   |
|   I64   |      I64      |     false     |      2^28      |     0     |   1.232 ms |       0.91% |   1.107 ms |       0.71% | -125.832 us | -10.21% |   FAST   |
|  I128   |      I64      |     false     |      2^16      |     1     |  11.682 us |       2.83% |  11.789 us |       2.79% |    0.107 us |   0.91% |   SAME   |
|  I128   |      I64      |     false     |      2^20      |     1     |  30.813 us |       2.17% |  26.826 us |       1.96% |   -3.987 us | -12.94% |   FAST   |
|  I128   |      I64      |     false     |      2^24      |     1     | 342.415 us |       1.27% | 299.214 us |       0.37% |  -43.201 us | -12.62% |   FAST   |
|  I128   |      I64      |     false     |      2^28      |     1     |   5.342 ms |       0.36% |   4.634 ms |       0.03% | -708.062 us | -13.25% |   FAST   |
|  I128   |      I64      |     false     |      2^16      |   0.544   |  11.582 us |       4.97% |  11.140 us |       5.01% |   -0.441 us |  -3.81% |   SAME   |
|  I128   |      I64      |     false     |      2^20      |   0.544   |  29.092 us |       2.56% |  24.964 us |       2.04% |   -4.128 us | -14.19% |   FAST   |
|  I128   |      I64      |     false     |      2^24      |   0.544   | 279.476 us |       1.51% | 231.322 us |       0.38% |  -48.154 us | -17.23% |   FAST   |
|  I128   |      I64      |     false     |      2^28      |   0.544   |   4.280 ms |       0.39% |   3.497 ms |       0.07% | -782.907 us | -18.29% |   FAST   |
|  I128   |      I64      |     false     |      2^16      |     0     |  11.002 us |       5.16% |  10.583 us |       5.63% |   -0.419 us |  -3.81% |   SAME   |
|  I128   |      I64      |     false     |      2^20      |     0     |  26.415 us |       2.35% |  22.855 us |       1.78% |   -3.561 us | -13.48% |   FAST   |
|  I128   |      I64      |     false     |      2^24      |     0     | 184.438 us |       1.17% | 159.759 us |       0.64% |  -24.680 us | -13.38% |   FAST   |
|  I128   |      I64      |     false     |      2^28      |     0     |   2.523 ms |       0.24% |   2.199 ms |       0.28% | -324.129 us | -12.84% |   FAST   |
|   F32   |      I64      |     false     |      2^16      |     1     |  10.695 us |       3.56% |  10.606 us |       3.32% |   -0.089 us |  -0.83% |   SAME   |
|   F32   |      I64      |     false     |      2^20      |     1     |  14.659 us |       4.07% |  14.137 us |       4.45% |   -0.521 us |  -3.56% |   SAME   |
|   F32   |      I64      |     false     |      2^24      |     1     |  89.397 us |       2.84% |  81.415 us |       0.77% |   -7.982 us |  -8.93% |   FAST   |
|   F32   |      I64      |     false     |      2^28      |     1     |   1.341 ms |       0.97% |   1.168 ms |       0.52% | -172.642 us | -12.88% |   FAST   |
|   F32   |      I64      |     false     |      2^16      |   0.544   |  10.250 us |       3.16% |  10.219 us |       4.29% |   -0.032 us |  -0.31% |   SAME   |
|   F32   |      I64      |     false     |      2^20      |   0.544   |  14.589 us |       2.62% |  13.874 us |       3.16% |   -0.715 us |  -4.90% |   FAST   |
|   F32   |      I64      |     false     |      2^24      |   0.544   |  64.751 us |       2.37% |  57.665 us |       1.24% |   -7.085 us | -10.94% |   FAST   |
|   F32   |      I64      |     false     |      2^28      |   0.544   | 771.697 us |       1.06% | 677.033 us |       0.69% |  -94.664 us | -12.27% |   FAST   |
|   F32   |      I64      |     false     |      2^16      |     0     |   9.751 us |       5.99% |   9.885 us |       6.13% |    0.135 us |   1.38% |   SAME   |
|   F32   |      I64      |     false     |      2^20      |     0     |  14.061 us |       2.60% |  13.324 us |       2.92% |   -0.737 us |  -5.24% |   FAST   |
|   F32   |      I64      |     false     |      2^24      |     0     |  63.118 us |       2.28% |  57.034 us |       1.24% |   -6.084 us |  -9.64% |   FAST   |
|   F32   |      I64      |     false     |      2^28      |     0     | 650.575 us |       1.49% | 575.478 us |       1.21% |  -75.097 us | -11.54% |   FAST   |
|   F64   |      I64      |     false     |      2^16      |     1     |  10.124 us |       5.89% |  11.027 us |       4.74% |    0.903 us |   8.92% |   SLOW   |
|   F64   |      I64      |     false     |      2^20      |     1     |  18.100 us |       2.20% |  17.825 us |       2.14% |   -0.275 us |  -1.52% |   SAME   |
|   F64   |      I64      |     false     |      2^24      |     1     | 164.291 us |       2.12% | 154.609 us |       0.61% |   -9.682 us |  -5.89% |   FAST   |
|   F64   |      I64      |     false     |      2^28      |     1     |   2.544 ms |       0.53% |   2.325 ms |       0.17% | -218.923 us |  -8.61% |   FAST   |
|   F64   |      I64      |     false     |      2^16      |   0.544   |  10.038 us |       6.12% |  10.515 us |       4.99% |    0.478 us |   4.76% |   SAME   |
|   F64   |      I64      |     false     |      2^20      |   0.544   |  17.147 us |       1.96% |  16.777 us |       2.34% |   -0.371 us |  -2.16% |   FAST   |
|   F64   |      I64      |     false     |      2^24      |   0.544   | 109.264 us |       2.73% |  97.383 us |       0.91% |  -11.881 us | -10.87% |   FAST   |
|   F64   |      I64      |     false     |      2^28      |   0.544   |   1.482 ms |       0.85% |   1.299 ms |       0.50% | -183.133 us | -12.36% |   FAST   |
|   F64   |      I64      |     false     |      2^16      |     0     |   9.625 us |       5.79% |  10.356 us |       5.31% |    0.731 us |   7.60% |   SLOW   |
|   F64   |      I64      |     false     |      2^20      |     0     |  16.515 us |       2.22% |  16.106 us |       2.37% |   -0.409 us |  -2.48% |   FAST   |
|   F64   |      I64      |     false     |      2^24      |     0     |  97.576 us |       2.10% |  92.009 us |       0.73% |   -5.567 us |  -5.71% |   FAST   |
|   F64   |      I64      |     false     |      2^28      |     0     |   1.229 ms |       0.88% |   1.106 ms |       0.71% | -123.004 us | -10.01% |   FAST   |


</details>

<details>
<summary>
Comparing cub.bench.select.flagged.base decoupled look-back versus atomics-based on H100
</summary>


|  T{ct}  |  OffsetT{ct}  |  InPlace{ct}  |  Elements{io}  |  Entropy  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|---------------|----------------|-----------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I64      |     false     |      2^16      |     1     |  11.402 us |       4.79% |  11.555 us |       5.13% |    0.154 us |   1.35% |   SAME   |
|   I8    |      I64      |     false     |      2^20      |     1     |  13.840 us |       2.16% |  13.896 us |       2.70% |    0.057 us |   0.41% |   SAME   |
|   I8    |      I64      |     false     |      2^24      |     1     |  64.390 us |       1.43% |  56.200 us |       0.70% |   -8.190 us | -12.72% |   FAST   |
|   I8    |      I64      |     false     |      2^28      |     1     | 845.652 us |       0.50% | 689.456 us |       0.42% | -156.196 us | -18.47% |   FAST   |
|   I8    |      I64      |     false     |      2^16      |   0.544   |  11.263 us |       5.12% |  11.480 us |       4.18% |    0.217 us |   1.93% |   SAME   |
|   I8    |      I64      |     false     |      2^20      |   0.544   |  14.126 us |       2.60% |  14.017 us |       2.62% |   -0.109 us |  -0.77% |   SAME   |
|   I8    |      I64      |     false     |      2^24      |   0.544   |  62.785 us |       1.52% |  55.530 us |       0.73% |   -7.254 us | -11.55% |   FAST   |
|   I8    |      I64      |     false     |      2^28      |   0.544   | 817.682 us |       0.50% | 671.538 us |       0.33% | -146.144 us | -17.87% |   FAST   |
|   I8    |      I64      |     false     |      2^16      |     0     |  10.905 us |       4.60% |  11.069 us |       4.79% |    0.164 us |   1.50% |   SAME   |
|   I8    |      I64      |     false     |      2^20      |     0     |  13.323 us |       4.26% |  12.976 us |       4.63% |   -0.347 us |  -2.60% |   SAME   |
|   I8    |      I64      |     false     |      2^24      |     0     |  55.495 us |       1.63% |  47.583 us |       1.43% |   -7.912 us | -14.26% |   FAST   |
|   I8    |      I64      |     false     |      2^28      |     0     | 664.027 us |       0.33% | 516.344 us |       0.14% | -147.682 us | -22.24% |   FAST   |
|   I16   |      I64      |     false     |      2^16      |     1     |  11.079 us |       3.42% |  11.439 us |       4.32% |    0.360 us |   3.25% |   SAME   |
|   I16   |      I64      |     false     |      2^20      |     1     |  14.660 us |       4.37% |  15.178 us |       4.11% |    0.518 us |   3.53% |   SAME   |
|   I16   |      I64      |     false     |      2^24      |     1     |  80.300 us |       2.16% |  71.237 us |       0.94% |   -9.063 us | -11.29% |   FAST   |
|   I16   |      I64      |     false     |      2^28      |     1     |   1.009 ms |       0.81% | 876.048 us |       0.66% | -132.688 us | -13.15% |   FAST   |
|   I16   |      I64      |     false     |      2^16      |   0.544   |  10.920 us |       3.61% |  11.346 us |       2.86% |    0.426 us |   3.90% |   SLOW   |
|   I16   |      I64      |     false     |      2^20      |   0.544   |  14.323 us |       4.53% |  14.432 us |       4.82% |    0.109 us |   0.76% |   SAME   |
|   I16   |      I64      |     false     |      2^24      |   0.544   |  74.626 us |       2.38% |  67.002 us |       0.95% |   -7.624 us | -10.22% |   FAST   |
|   I16   |      I64      |     false     |      2^28      |   0.544   | 924.043 us |       0.60% | 783.876 us |       0.55% | -140.167 us | -15.17% |   FAST   |
|   I16   |      I64      |     false     |      2^16      |     0     |  10.442 us |       3.16% |  10.900 us |       3.01% |    0.459 us |   4.39% |   SLOW   |
|   I16   |      I64      |     false     |      2^20      |     0     |  13.653 us |       4.30% |  13.528 us |       4.91% |   -0.125 us |  -0.92% |   SAME   |
|   I16   |      I64      |     false     |      2^24      |     0     |  66.517 us |       2.08% |  58.627 us |       0.95% |   -7.890 us | -11.86% |   FAST   |
|   I16   |      I64      |     false     |      2^28      |     0     | 703.121 us |       0.29% | 568.228 us |       0.13% | -134.893 us | -19.18% |   FAST   |
|   I32   |      I64      |     false     |      2^16      |     1     |  10.593 us |       5.98% |  10.872 us |       5.77% |    0.279 us |   2.63% |   SAME   |
|   I32   |      I64      |     false     |      2^20      |     1     |  15.872 us |       2.29% |  15.230 us |       2.49% |   -0.641 us |  -4.04% |   FAST   |
|   I32   |      I64      |     false     |      2^24      |     1     | 105.467 us |       1.48% |  93.813 us |       0.64% |  -11.654 us | -11.05% |   FAST   |
|   I32   |      I64      |     false     |      2^28      |     1     |   1.514 ms |       0.59% |   1.371 ms |       0.96% | -142.374 us |  -9.41% |   FAST   |
|   I32   |      I64      |     false     |      2^16      |   0.544   |  10.357 us |       5.57% |  10.648 us |       5.28% |    0.290 us |   2.80% |   SAME   |
|   I32   |      I64      |     false     |      2^20      |   0.544   |  15.756 us |       2.42% |  15.093 us |       2.49% |   -0.662 us |  -4.20% |   FAST   |
|   I32   |      I64      |     false     |      2^24      |   0.544   |  93.953 us |       1.52% |  83.399 us |       0.73% |  -10.555 us | -11.23% |   FAST   |
|   I32   |      I64      |     false     |      2^28      |   0.544   |   1.264 ms |       0.68% |   1.163 ms |       0.50% | -100.935 us |  -7.98% |   FAST   |
|   I32   |      I64      |     false     |      2^16      |     0     |  10.182 us |       6.02% |  10.376 us |       5.98% |    0.194 us |   1.90% |   SAME   |
|   I32   |      I64      |     false     |      2^20      |     0     |  15.377 us |       2.19% |  14.705 us |       2.04% |   -0.672 us |  -4.37% |   FAST   |
|   I32   |      I64      |     false     |      2^24      |     0     |  79.714 us |       1.53% |  69.300 us |       0.92% |  -10.415 us | -13.07% |   FAST   |
|   I32   |      I64      |     false     |      2^28      |     0     | 855.289 us |       0.33% | 702.761 us |       0.28% | -152.528 us | -17.83% |   FAST   |
|   I64   |      I64      |     false     |      2^16      |     1     |  10.814 us |       3.67% |  11.361 us |       3.46% |    0.547 us |   5.06% |   SLOW   |
|   I64   |      I64      |     false     |      2^20      |     1     |  20.617 us |       2.94% |  20.062 us |       3.17% |   -0.555 us |  -2.69% |   SAME   |
|   I64   |      I64      |     false     |      2^24      |     1     | 180.186 us |       1.37% | 165.008 us |       0.55% |  -15.179 us |  -8.42% |   FAST   |
|   I64   |      I64      |     false     |      2^28      |     1     |   2.738 ms |       0.36% |   2.460 ms |       0.05% | -277.646 us | -10.14% |   FAST   |
|   I64   |      I64      |     false     |      2^16      |   0.544   |  10.816 us |       3.43% |  11.203 us |       3.23% |    0.387 us |   3.58% |   SLOW   |
|   I64   |      I64      |     false     |      2^20      |   0.544   |  20.297 us |       3.13% |  19.959 us |       2.99% |   -0.338 us |  -1.66% |   SAME   |
|   I64   |      I64      |     false     |      2^24      |   0.544   | 153.264 us |       1.51% | 132.448 us |       0.79% |  -20.817 us | -13.58% |   FAST   |
|   I64   |      I64      |     false     |      2^28      |   0.544   |   2.245 ms |       0.63% |   2.002 ms |       0.50% | -243.009 us | -10.82% |   FAST   |
|   I64   |      I64      |     false     |      2^16      |     0     |   9.983 us |       2.72% |  10.373 us |       3.38% |    0.389 us |   3.90% |   SLOW   |
|   I64   |      I64      |     false     |      2^20      |     0     |  18.656 us |       3.31% |  17.852 us |       3.49% |   -0.804 us |  -4.31% |   FAST   |
|   I64   |      I64      |     false     |      2^24      |     0     | 115.083 us |       1.51% | 101.190 us |       0.56% |  -13.893 us | -12.07% |   FAST   |
|   I64   |      I64      |     false     |      2^28      |     0     |   1.403 ms |       0.46% |   1.276 ms |       0.18% | -127.537 us |  -9.09% |   FAST   |
|  I128   |      I64      |     false     |      2^16      |     1     |  10.979 us |       3.35% |  10.940 us |       2.87% |   -0.039 us |  -0.35% |   SAME   |
|  I128   |      I64      |     false     |      2^20      |     1     |  30.636 us |       2.90% |  26.363 us |       2.44% |   -4.273 us | -13.95% |   FAST   |
|  I128   |      I64      |     false     |      2^24      |     1     | 345.620 us |       1.38% | 307.415 us |       0.39% |  -38.205 us | -11.05% |   FAST   |
|  I128   |      I64      |     false     |      2^28      |     1     |   5.407 ms |       0.43% |   4.761 ms |       0.04% | -645.328 us | -11.94% |   FAST   |
|  I128   |      I64      |     false     |      2^16      |   0.544   |  11.322 us |       5.35% |  11.030 us |       5.66% |   -0.292 us |  -2.58% |   SAME   |
|  I128   |      I64      |     false     |      2^20      |   0.544   |  28.602 us |       2.74% |  24.543 us |       2.11% |   -4.059 us | -14.19% |   FAST   |
|  I128   |      I64      |     false     |      2^24      |   0.544   | 280.222 us |       1.52% | 239.170 us |       0.29% |  -41.052 us | -14.65% |   FAST   |
|  I128   |      I64      |     false     |      2^28      |   0.544   |   4.289 ms |       0.75% |   3.635 ms |       0.73% | -654.051 us | -15.25% |   FAST   |
|  I128   |      I64      |     false     |      2^16      |     0     |  10.828 us |       5.35% |  10.727 us |       5.71% |   -0.101 us |  -0.93% |   SAME   |
|  I128   |      I64      |     false     |      2^20      |     0     |  26.235 us |       2.33% |  22.923 us |       1.84% |   -3.312 us | -12.63% |   FAST   |
|  I128   |      I64      |     false     |      2^24      |     0     | 186.111 us |       1.10% | 168.548 us |       0.46% |  -17.563 us |  -9.44% |   FAST   |
|  I128   |      I64      |     false     |      2^28      |     0     |   2.589 ms |       0.28% |   2.315 ms |       0.07% | -274.450 us | -10.60% |   FAST   |
|   F32   |      I64      |     false     |      2^16      |     1     |  10.772 us |       3.39% |  11.131 us |       3.15% |    0.360 us |   3.34% |   SLOW   |
|   F32   |      I64      |     false     |      2^20      |     1     |  16.226 us |       3.44% |  15.038 us |       4.29% |   -1.187 us |  -7.32% |   FAST   |
|   F32   |      I64      |     false     |      2^24      |     1     | 105.542 us |       1.45% |  93.665 us |       0.62% |  -11.877 us | -11.25% |   FAST   |
|   F32   |      I64      |     false     |      2^28      |     1     |   1.511 ms |       0.58% |   1.364 ms |       0.50% | -147.038 us |  -9.73% |   FAST   |
|   F32   |      I64      |     false     |      2^16      |   0.544   |  10.632 us |       4.19% |  10.620 us |       3.47% |   -0.012 us |  -0.12% |   SAME   |
|   F32   |      I64      |     false     |      2^20      |   0.544   |  15.909 us |       2.30% |  15.057 us |       2.35% |   -0.852 us |  -5.35% |   FAST   |
|   F32   |      I64      |     false     |      2^24      |   0.544   |  94.065 us |       1.50% |  83.444 us |       0.71% |  -10.620 us | -11.29% |   FAST   |
|   F32   |      I64      |     false     |      2^28      |   0.544   |   1.263 ms |       0.73% |   1.164 ms |       0.50% |  -99.371 us |  -7.87% |   FAST   |
|   F32   |      I64      |     false     |      2^16      |     0     |  10.293 us |       5.44% |  10.316 us |       5.92% |    0.024 us |   0.23% |   SAME   |
|   F32   |      I64      |     false     |      2^20      |     0     |  15.315 us |       2.56% |  14.490 us |       2.40% |   -0.825 us |  -5.38% |   FAST   |
|   F32   |      I64      |     false     |      2^24      |     0     |  79.716 us |       1.54% |  69.107 us |       0.90% |  -10.609 us | -13.31% |   FAST   |
|   F32   |      I64      |     false     |      2^28      |     0     | 853.513 us |       0.35% | 702.512 us |       0.30% | -151.001 us | -17.69% |   FAST   |
|   F64   |      I64      |     false     |      2^16      |     1     |  10.552 us |       4.97% |  11.404 us |       4.65% |    0.852 us |   8.08% |   SLOW   |
|   F64   |      I64      |     false     |      2^20      |     1     |  20.126 us |       2.36% |  20.118 us |       2.08% |   -0.008 us |  -0.04% |   SAME   |
|   F64   |      I64      |     false     |      2^24      |     1     | 179.607 us |       1.35% | 165.026 us |       0.59% |  -14.581 us |  -8.12% |   FAST   |
|   F64   |      I64      |     false     |      2^28      |     1     |   2.733 ms |       0.37% |   2.460 ms |       0.05% | -272.402 us |  -9.97% |   FAST   |
|   F64   |      I64      |     false     |      2^16      |   0.544   |  10.478 us |       5.69% |  11.252 us |       4.99% |    0.774 us |   7.38% |   SLOW   |
|   F64   |      I64      |     false     |      2^20      |   0.544   |  19.938 us |       2.04% |  19.906 us |       2.07% |   -0.032 us |  -0.16% |   SAME   |
|   F64   |      I64      |     false     |      2^24      |   0.544   | 152.733 us |       1.52% | 132.451 us |       0.84% |  -20.282 us | -13.28% |   FAST   |
|   F64   |      I64      |     false     |      2^28      |   0.544   |   2.242 ms |       0.64% |   2.002 ms |       0.50% | -240.156 us | -10.71% |   FAST   |
|   F64   |      I64      |     false     |      2^16      |     0     |   9.977 us |       6.29% |  10.674 us |       4.98% |    0.697 us |   6.99% |   SLOW   |
|   F64   |      I64      |     false     |      2^20      |     0     |  18.475 us |       2.28% |  18.065 us |       2.09% |   -0.410 us |  -2.22% |   FAST   |
|   F64   |      I64      |     false     |      2^24      |     0     | 114.831 us |       1.49% | 101.430 us |       0.72% |  -13.401 us | -11.67% |   FAST   |
|   F64   |      I64      |     false     |      2^28      |     0     |   1.401 ms |       0.45% |   1.276 ms |       0.17% | -124.500 us |  -8.89% |   FAST   |


</details>

<details>
<summary>
Comparing cub.bench.select.unique.base decoupled look-back versus atomics-based on H100
</summary>


|  T{ct}  |  OffsetT{ct}  |  InPlace{ct}  |  Elements{io}  |  MaxSegSize  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|---------------|----------------|--------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I64      |     false     |      2^16      |     2^1      |   9.963 us |       5.23% |  10.396 us |       5.35% |    0.433 us |   4.34% |   SAME   |
|   I8    |      I64      |     false     |      2^20      |     2^1      |  12.234 us |       2.79% |  11.761 us |       2.61% |   -0.473 us |  -3.87% |   FAST   |
|   I8    |      I64      |     false     |      2^24      |     2^1      |  51.457 us |       1.32% |  43.563 us |       0.98% |   -7.895 us | -15.34% |   FAST   |
|   I8    |      I64      |     false     |      2^28      |     2^1      | 691.310 us |       0.50% | 533.062 us |       0.48% | -158.248 us | -22.89% |   FAST   |
|   I8    |      I64      |     false     |      2^16      |     2^4      |   9.629 us |       5.87% |   9.929 us |       5.39% |    0.301 us |   3.12% |   SAME   |
|   I8    |      I64      |     false     |      2^20      |     2^4      |  12.531 us |       2.72% |  11.393 us |       4.75% |   -1.138 us |  -9.08% |   FAST   |
|   I8    |      I64      |     false     |      2^24      |     2^4      |  44.468 us |       1.43% |  35.708 us |       1.33% |   -8.760 us | -19.70% |   FAST   |
|   I8    |      I64      |     false     |      2^28      |     2^4      | 563.566 us |       0.50% | 413.438 us |       0.39% | -150.128 us | -26.64% |   FAST   |
|   I8    |      I64      |     false     |      2^16      |     2^8      |   9.920 us |       5.75% |  10.270 us |       5.00% |    0.350 us |   3.53% |   SAME   |
|   I8    |      I64      |     false     |      2^20      |     2^8      |  12.052 us |       4.55% |  11.284 us |       5.18% |   -0.768 us |  -6.37% |   FAST   |
|   I8    |      I64      |     false     |      2^24      |     2^8      |  46.285 us |       1.27% |  37.311 us |       1.45% |   -8.974 us | -19.39% |   FAST   |
|   I8    |      I64      |     false     |      2^28      |     2^8      | 584.265 us |       0.50% | 425.946 us |       0.36% | -158.320 us | -27.10% |   FAST   |
|   I16   |      I64      |     false     |      2^16      |     2^1      |  10.661 us |       2.93% |  10.534 us |       3.96% |   -0.127 us |  -1.19% |   SAME   |
|   I16   |      I64      |     false     |      2^20      |     2^1      |  13.734 us |       4.19% |  12.632 us |       4.93% |   -1.102 us |  -8.02% |   FAST   |
|   I16   |      I64      |     false     |      2^24      |     2^1      |  59.900 us |       2.88% |  48.855 us |       1.28% |  -11.045 us | -18.44% |   FAST   |
|   I16   |      I64      |     false     |      2^28      |     2^1      | 776.697 us |       1.77% | 585.069 us |       2.37% | -191.627 us | -24.67% |   FAST   |
|   I16   |      I64      |     false     |      2^16      |     2^4      |  10.225 us |       3.54% |  10.102 us |       4.51% |   -0.123 us |  -1.21% |   SAME   |
|   I16   |      I64      |     false     |      2^20      |     2^4      |  14.029 us |       4.21% |  12.195 us |       5.58% |   -1.834 us | -13.08% |   FAST   |
|   I16   |      I64      |     false     |      2^24      |     2^4      |  51.684 us |       2.65% |  42.169 us |       1.41% |   -9.515 us | -18.41% |   FAST   |
|   I16   |      I64      |     false     |      2^28      |     2^4      | 589.150 us |       0.93% | 408.181 us |       1.62% | -180.969 us | -30.72% |   FAST   |
|   I16   |      I64      |     false     |      2^16      |     2^8      |  10.603 us |       2.67% |  10.427 us |       3.93% |   -0.176 us |  -1.66% |   SAME   |
|   I16   |      I64      |     false     |      2^20      |     2^8      |  13.608 us |       4.18% |  12.143 us |       5.45% |   -1.465 us | -10.77% |   FAST   |
|   I16   |      I64      |     false     |      2^24      |     2^8      |  52.280 us |       2.74% |  42.467 us |       1.46% |   -9.813 us | -18.77% |   FAST   |
|   I16   |      I64      |     false     |      2^28      |     2^8      | 568.914 us |       0.91% | 396.731 us |       0.76% | -172.183 us | -30.27% |   FAST   |
|   I32   |      I64      |     false     |      2^16      |     2^1      |  10.909 us |       5.43% |  10.970 us |       5.28% |    0.061 us |   0.55% |   SAME   |
|   I32   |      I64      |     false     |      2^20      |     2^1      |  15.371 us |       2.56% |  14.620 us |       2.54% |   -0.751 us |  -4.88% |   FAST   |
|   I32   |      I64      |     false     |      2^24      |     2^1      |  84.644 us |       2.69% |  70.667 us |       1.20% |  -13.978 us | -16.51% |   FAST   |
|   I32   |      I64      |     false     |      2^28      |     2^1      |   1.166 ms |       1.33% | 960.970 us |       1.07% | -205.014 us | -17.58% |   FAST   |
|   I32   |      I64      |     false     |      2^16      |     2^4      |  10.707 us |       5.40% |  10.762 us |       6.01% |    0.054 us |   0.51% |   SAME   |
|   I32   |      I64      |     false     |      2^20      |     2^4      |  14.724 us |       2.22% |  13.907 us |       2.65% |   -0.817 us |  -5.55% |   FAST   |
|   I32   |      I64      |     false     |      2^24      |     2^4      |  67.628 us |       2.31% |  58.587 us |       1.18% |   -9.041 us | -13.37% |   FAST   |
|   I32   |      I64      |     false     |      2^28      |     2^4      | 804.783 us |       1.10% | 696.179 us |       0.74% | -108.604 us | -13.49% |   FAST   |
|   I32   |      I64      |     false     |      2^16      |     2^8      |  10.444 us |       5.29% |  10.588 us |       5.82% |    0.145 us |   1.38% |   SAME   |
|   I32   |      I64      |     false     |      2^20      |     2^8      |  14.476 us |       2.15% |  13.642 us |       2.46% |   -0.833 us |  -5.76% |   FAST   |
|   I32   |      I64      |     false     |      2^24      |     2^8      |  65.945 us |       2.52% |  57.820 us |       1.23% |   -8.126 us | -12.32% |   FAST   |
|   I32   |      I64      |     false     |      2^28      |     2^8      | 696.585 us |       1.13% | 610.784 us |       0.81% |  -85.801 us | -12.32% |   FAST   |
|   I64   |      I64      |     false     |      2^16      |     2^1      |  10.466 us |       2.79% |  10.821 us |       3.78% |    0.355 us |   3.39% |   SLOW   |
|   I64   |      I64      |     false     |      2^20      |     2^1      |  18.324 us |       3.45% |  17.679 us |       3.94% |   -0.645 us |  -3.52% |   FAST   |
|   I64   |      I64      |     false     |      2^24      |     2^1      | 148.075 us |       2.63% | 130.662 us |       0.95% |  -17.413 us | -11.76% |   FAST   |
|   I64   |      I64      |     false     |      2^28      |     2^1      |   2.195 ms |       1.06% |   1.910 ms |       0.72% | -285.475 us | -13.00% |   FAST   |
|   I64   |      I64      |     false     |      2^16      |     2^4      |  10.132 us |       2.95% |  10.335 us |       4.16% |    0.203 us |   2.00% |   SAME   |
|   I64   |      I64      |     false     |      2^20      |     2^4      |  17.453 us |       3.20% |  16.519 us |       3.92% |   -0.934 us |  -5.35% |   FAST   |
|   I64   |      I64      |     false     |      2^24      |     2^4      | 109.007 us |       2.21% |  98.843 us |       0.95% |  -10.164 us |  -9.32% |   FAST   |
|   I64   |      I64      |     false     |      2^28      |     2^4      |   1.499 ms |       0.77% |   1.316 ms |       0.50% | -182.518 us | -12.18% |   FAST   |
|   I64   |      I64      |     false     |      2^16      |     2^8      |  10.022 us |       3.34% |  10.587 us |       3.82% |    0.565 us |   5.64% |   SLOW   |
|   I64   |      I64      |     false     |      2^20      |     2^8      |  16.974 us |       3.50% |  16.554 us |       4.13% |   -0.420 us |  -2.48% |   SAME   |
|   I64   |      I64      |     false     |      2^24      |     2^8      | 102.303 us |       2.14% |  93.628 us |       0.66% |   -8.676 us |  -8.48% |   FAST   |
|   I64   |      I64      |     false     |      2^28      |     2^8      |   1.303 ms |       0.64% |   1.162 ms |       0.50% | -141.669 us | -10.87% |   FAST   |
|  I128   |      I64      |     false     |      2^16      |     2^1      |  11.563 us |       3.59% |  11.583 us |       3.11% |    0.020 us |   0.17% |   SAME   |
|  I128   |      I64      |     false     |      2^20      |     2^1      |  29.713 us |       2.15% |  25.687 us |       1.99% |   -4.026 us | -13.55% |   FAST   |
|  I128   |      I64      |     false     |      2^24      |     2^1      | 297.243 us |       1.49% | 249.149 us |       0.53% |  -48.094 us | -16.18% |   FAST   |
|  I128   |      I64      |     false     |      2^28      |     2^1      |   4.573 ms |       0.61% |   3.802 ms |       0.60% | -770.961 us | -16.86% |   FAST   |
|  I128   |      I64      |     false     |      2^16      |     2^4      |  11.161 us |       5.05% |  10.604 us |       5.63% |   -0.557 us |  -4.99% |   SAME   |
|  I128   |      I64      |     false     |      2^20      |     2^4      |  26.908 us |       2.55% |  23.093 us |       1.91% |   -3.815 us | -14.18% |   FAST   |
|  I128   |      I64      |     false     |      2^24      |     2^4      | 212.701 us |       1.37% | 182.362 us |       0.66% |  -30.339 us | -14.26% |   FAST   |
|  I128   |      I64      |     false     |      2^28      |     2^4      |   3.175 ms |       0.27% |   2.683 ms |       0.12% | -492.389 us | -15.51% |   FAST   |
|  I128   |      I64      |     false     |      2^16      |     2^8      |  11.028 us |       5.05% |  10.444 us |       5.99% |   -0.583 us |  -5.29% |   FAST   |
|  I128   |      I64      |     false     |      2^20      |     2^8      |  26.193 us |       2.34% |  22.646 us |       1.89% |   -3.547 us | -13.54% |   FAST   |
|  I128   |      I64      |     false     |      2^24      |     2^8      | 188.282 us |       1.19% | 164.661 us |       0.53% |  -23.620 us | -12.55% |   FAST   |
|  I128   |      I64      |     false     |      2^28      |     2^8      |   2.611 ms |       0.28% |   2.314 ms |       0.09% | -297.604 us | -11.40% |   FAST   |
|   F32   |      I64      |     false     |      2^16      |     2^1      |  10.918 us |       3.20% |  10.713 us |       3.55% |   -0.205 us |  -1.88% |   SAME   |
|   F32   |      I64      |     false     |      2^20      |     2^1      |  15.022 us |       4.17% |  14.778 us |       4.52% |   -0.244 us |  -1.63% |   SAME   |
|   F32   |      I64      |     false     |      2^24      |     2^1      |  84.147 us |       2.66% |  70.852 us |       1.02% |  -13.296 us | -15.80% |   FAST   |
|   F32   |      I64      |     false     |      2^28      |     2^1      | 847.044 us |       1.41% | 727.158 us |       1.08% | -119.886 us | -14.15% |   FAST   |
|   F32   |      I64      |     false     |      2^16      |     2^4      |  10.405 us |       3.73% |  10.891 us |       3.19% |    0.485 us |   4.66% |   SLOW   |
|   F32   |      I64      |     false     |      2^20      |     2^4      |  14.299 us |       2.55% |  14.027 us |       2.60% |   -0.272 us |  -1.91% |   SAME   |
|   F32   |      I64      |     false     |      2^24      |     2^4      |  67.109 us |       2.34% |  58.778 us |       1.22% |   -8.331 us | -12.41% |   FAST   |
|   F32   |      I64      |     false     |      2^28      |     2^4      | 781.748 us |       1.19% | 687.915 us |       0.82% |  -93.833 us | -12.00% |   FAST   |
|   F32   |      I64      |     false     |      2^16      |     2^8      |  10.008 us |       5.71% |  10.552 us |       5.58% |    0.545 us |   5.44% |   SAME   |
|   F32   |      I64      |     false     |      2^20      |     2^8      |  14.429 us |       2.66% |  14.141 us |       2.38% |   -0.288 us |  -2.00% |   SAME   |
|   F32   |      I64      |     false     |      2^24      |     2^8      |  65.858 us |       2.46% |  58.256 us |       1.13% |   -7.602 us | -11.54% |   FAST   |
|   F32   |      I64      |     false     |      2^28      |     2^8      | 694.193 us |       1.14% | 612.093 us |       0.82% |  -82.100 us | -11.83% |   FAST   |
|   F64   |      I64      |     false     |      2^16      |     2^1      |  10.695 us |       5.07% |  10.710 us |       4.92% |    0.015 us |   0.14% |   SAME   |
|   F64   |      I64      |     false     |      2^20      |     2^1      |  18.645 us |       1.88% |  17.775 us |       1.95% |   -0.870 us |  -4.67% |   FAST   |
|   F64   |      I64      |     false     |      2^24      |     2^1      | 148.377 us |       2.61% | 130.654 us |       1.05% |  -17.722 us | -11.94% |   FAST   |
|   F64   |      I64      |     false     |      2^28      |     2^1      |   2.196 ms |       1.07% |   1.910 ms |       0.72% | -286.286 us | -13.04% |   FAST   |
|   F64   |      I64      |     false     |      2^16      |     2^4      |  10.407 us |       5.80% |  10.348 us |       5.43% |   -0.059 us |  -0.57% |   SAME   |
|   F64   |      I64      |     false     |      2^20      |     2^4      |  17.575 us |       1.96% |  16.347 us |       1.85% |   -1.228 us |  -6.99% |   FAST   |
|   F64   |      I64      |     false     |      2^24      |     2^4      | 108.974 us |       2.14% |  98.599 us |       1.09% |  -10.376 us |  -9.52% |   FAST   |
|   F64   |      I64      |     false     |      2^28      |     2^4      |   1.498 ms |       0.77% |   1.315 ms |       0.50% | -182.422 us | -12.18% |   FAST   |
|   F64   |      I64      |     false     |      2^16      |     2^8      |  10.200 us |       6.09% |  10.237 us |       5.30% |    0.037 us |   0.36% |   SAME   |
|   F64   |      I64      |     false     |      2^20      |     2^8      |  17.225 us |       2.18% |  16.082 us |       2.12% |   -1.143 us |  -6.64% |   FAST   |
|   F64   |      I64      |     false     |      2^24      |     2^8      | 102.103 us |       2.05% |  93.109 us |       0.83% |   -8.994 us |  -8.81% |   FAST   |
|   F64   |      I64      |     false     |      2^28      |     2^8      |   1.299 ms |       0.61% |   1.161 ms |       0.50% | -138.019 us | -10.63% |   FAST   |


</details>
